### PR TITLE
Controller takes a zeroconf_instance

### DIFF
--- a/aiohomekit/controller/ip/connection.py
+++ b/aiohomekit/controller/ip/connection.py
@@ -528,7 +528,8 @@ class SecureHomeKitConnection(HomeKitConnection):
 
         try:
             self.host, self.port = await async_find_device_ip_and_port(
-                self.pairing_data["AccessoryPairingID"]
+                self.pairing_data["AccessoryPairingID"],
+                zeroconf_instance=self.owner.controller._zeroconf_instance,
             )
         except AccessoryNotFoundError:
             pass

--- a/aiohomekit/controller/ip/discovery.py
+++ b/aiohomekit/controller/ip/discovery.py
@@ -102,7 +102,7 @@ class IpDiscovery(object):
             pairing["AccessoryPort"] = self.port
             pairing["Connection"] = "IP"
 
-            obj = self.controller.pairings[alias] = IpPairing(pairing)
+            obj = self.controller.pairings[alias] = IpPairing(self.controller, pairing)
 
             await self.connection.close()
 

--- a/aiohomekit/controller/ip/pairing.py
+++ b/aiohomekit/controller/ip/pairing.py
@@ -55,14 +55,14 @@ class IpPairing(AbstractPairing):
     This represents a paired HomeKit IP accessory.
     """
 
-    def __init__(self, pairing_data):
+    def __init__(self, controller, pairing_data):
         """
         Initialize a Pairing by using the data either loaded from file or obtained after calling
         Controller.perform_pairing().
 
         :param pairing_data:
         """
-        super().__init__()
+        super().__init__(controller)
 
         self.pairing_data = pairing_data
         self.connection = SecureHomeKitConnection(self, self.pairing_data)

--- a/aiohomekit/controller/pairing.py
+++ b/aiohomekit/controller/pairing.py
@@ -19,7 +19,8 @@ from typing import Any, Dict
 
 
 class AbstractPairing(abc.ABC):
-    def __init__(self):
+    def __init__(self, controller):
+        self.controller = controller
         self.listeners = set()
         self.subscriptions = set()
 

--- a/aiohomekit/testing.py
+++ b/aiohomekit/testing.py
@@ -75,7 +75,7 @@ class FakeDiscovery(object):
             pairing_data["Connection"] = "IP"
 
             obj = self.controller.pairings[alias] = FakePairing(
-                pairing_data, self.accessories
+                self.controller, pairing_data, self.accessories
             )
             return obj
 
@@ -178,9 +178,9 @@ class FakePairing(AbstractPairing):
     class.
     """
 
-    def __init__(self, pairing_data, accessories: Accessories):
+    def __init__(self, controller, pairing_data, accessories: Accessories):
         """Create a fake pairing from an accessory model."""
-        super().__init__()
+        super().__init__(controller)
 
         self.accessories = accessories
         self.pairing_data = {}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -184,7 +184,7 @@ async def pairings(request, controller_and_paired_accessory, loop):
     """ Returns a pairing of pairngs. """
     left = controller_and_paired_accessory.get_pairings()["alias"]
 
-    right = IpPairing(left.pairing_data)
+    right = IpPairing(left.controller, left.pairing_data)
 
     yield (left, right)
 


### PR DESCRIPTION
@bdraco I thought about it some more and we didn't take into account [this](https://github.com/Jc2k/aiohomekit/blob/master/aiohomekit/controller/ip/connection.py#L530) case.

That's one of the ones that i'd like to be able to get rid of in the long run (or at least not call as often), but right now it's needed for some devices to stay working for more than a day.

The most natural way to get to the zeroconf_instance from that part of the code would be if there was a zeroconf_instance on controller i think, so thats what this PR does.

What do you think?