### PR TITLE
Remove stray zeroconf argument

### DIFF
--- a/aiohomekit/controller/controller.py
+++ b/aiohomekit/controller/controller.py
@@ -33,6 +33,7 @@ from .pairing import AbstractPairing
 if IP_TRANSPORT_SUPPORTED:
     from .ip import IpDiscovery, IpPairing
     from .ip.zeroconf import async_discover_homekit_devices
+    from aiohomekit.zeroconf import async_find_data_for_device_id
 
 
 class Controller(object):
@@ -88,10 +89,12 @@ class Controller(object):
         return tmp
 
     async def find_ip_by_device_id(self, device_id, max_seconds=10):
-        results = await self.discover_ip(max_seconds=max_seconds)
-        for result in results:
-            if result.device_id == device_id:
-                return result
+        if not IP_TRANSPORT_SUPPORTED:
+            raise TransportNotSupportedError("IP")
+        device = await async_find_data_for_device_id(
+            max_seconds=max_seconds, zeroconf_instance=self._zeroconf_instance
+        )
+        return IpDiscovery(self, device)
         raise AccessoryNotFoundError("No matching accessory found")
 
     @staticmethod

--- a/aiohomekit/controller/controller.py
+++ b/aiohomekit/controller/controller.py
@@ -88,9 +88,7 @@ class Controller(object):
         return tmp
 
     async def find_ip_by_device_id(self, device_id, max_seconds=10):
-        results = await self.discover_ip(
-            max_seconds=max_seconds, zeroconf_instance=self._zeroconf_instance
-        )
+        results = await self.discover_ip(max_seconds=max_seconds)
         for result in results:
             if result.device_id == device_id:
                 return result

--- a/aiohomekit/controller/controller.py
+++ b/aiohomekit/controller/controller.py
@@ -97,7 +97,6 @@ class Controller(object):
             zeroconf_instance=self._zeroconf_instance,
         )
         return IpDiscovery(self, device)
-        raise AccessoryNotFoundError("No matching accessory found")
 
     @staticmethod
     async def discover_ble(max_seconds=10, adapter="hci0"):

--- a/aiohomekit/controller/controller.py
+++ b/aiohomekit/controller/controller.py
@@ -92,7 +92,9 @@ class Controller(object):
         if not IP_TRANSPORT_SUPPORTED:
             raise TransportNotSupportedError("IP")
         device = await async_find_data_for_device_id(
-            max_seconds=max_seconds, zeroconf_instance=self._zeroconf_instance
+            device_id=device_id,
+            max_seconds=max_seconds,
+            zeroconf_instance=self._zeroconf_instance,
         )
         return IpDiscovery(self, device)
         raise AccessoryNotFoundError("No matching accessory found")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -73,7 +73,11 @@ async def controller_and_unpaired_accessory(request, loop):
         time.sleep(1)
 
     with mock.patch("aiohomekit.zeroconf._find_data_for_device_id") as find:
-        find.return_value = {"address": "127.0.0.1", "port": 51842}
+        find.return_value = {
+            "address": "127.0.0.1",
+            "port": 51842,
+            "id": "12:34:56:00:01:0A",
+        }
         with mock.patch.object(controller, "load_data", lambda x: None):
             with mock.patch("aiohomekit.__main__.Controller") as c:
                 c.return_value = controller
@@ -154,7 +158,11 @@ async def controller_and_paired_accessory(request, loop):
         time.sleep(1)
 
     with mock.patch("aiohomekit.zeroconf._find_data_for_device_id") as find:
-        find.return_value = {"address": "127.0.0.1", "port": 51842}
+        find.return_value = {
+            "address": "127.0.0.1",
+            "port": 51842,
+            "id": "12:34:56:00:01:0A",
+        }
         with mock.patch.object(controller, "load_data", lambda x: None):
             with mock.patch("aiohomekit.__main__.Controller") as c:
                 c.return_value = controller

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -72,8 +72,8 @@ async def controller_and_unpaired_accessory(request, loop):
             break
         time.sleep(1)
 
-    with mock.patch("aiohomekit.zeroconf._find_device_ip_and_port") as find:
-        find.return_value = ("127.0.0.1", 51842)
+    with mock.patch("aiohomekit.zeroconf._find_data_for_device_id") as find:
+        find.return_value = {"address": "127.0.0.1", "port": 51842}
         with mock.patch.object(controller, "load_data", lambda x: None):
             with mock.patch("aiohomekit.__main__.Controller") as c:
                 c.return_value = controller
@@ -153,8 +153,8 @@ async def controller_and_paired_accessory(request, loop):
             break
         time.sleep(1)
 
-    with mock.patch("aiohomekit.zeroconf._find_device_ip_and_port") as find:
-        find.return_value = ("127.0.0.1", 51842)
+    with mock.patch("aiohomekit.zeroconf._find_data_for_device_id") as find:
+        find.return_value = {"address": "127.0.0.1", "port": 51842}
         with mock.patch.object(controller, "load_data", lambda x: None):
             with mock.patch("aiohomekit.__main__.Controller") as c:
                 c.return_value = controller

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -15,3 +15,9 @@ async def test_remove_pairing(controller_and_paired_accessory):
     # Verify now gives an appropriate error
     with pytest.raises(AuthenticationError):
         await pairing.get_characteristics([(1, 9)])
+
+async def test_find_ip_by_device_id(controller_and_unpaired_accessory):
+    ip_discovery = await controller_and_unpaired_accessory.find_ip_by_device_id("12:34:56:00:01:0A", 10)
+
+    assert ip_discovery.host == "127.0.0.1"
+    assert ip_discovery.device_id == "12:34:56:00:01:0A"

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -16,8 +16,11 @@ async def test_remove_pairing(controller_and_paired_accessory):
     with pytest.raises(AuthenticationError):
         await pairing.get_characteristics([(1, 9)])
 
+
 async def test_find_ip_by_device_id(controller_and_unpaired_accessory):
-    ip_discovery = await controller_and_unpaired_accessory.find_ip_by_device_id("12:34:56:00:01:0A", 10)
+    ip_discovery = await controller_and_unpaired_accessory.find_ip_by_device_id(
+        "12:34:56:00:01:0A", 10
+    )
 
     assert ip_discovery.host == "127.0.0.1"
     assert ip_discovery.device_id == "12:34:56:00:01:0A"


### PR DESCRIPTION
```
2020-07-10 16:03:15 ERROR (MainThread) [aiohttp.server] Error handling request
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/aiohttp/web_protocol.py", line 418, in start
    resp = await task
  File "/usr/local/lib/python3.7/site-packages/aiohttp/web_app.py", line 458, in _handle
    resp = await handler(request)
  File "/usr/local/lib/python3.7/site-packages/aiohttp/web_middlewares.py", line 119, in impl
    return await handler(request)
  File "/usr/src/homeassistant/homeassistant/components/http/real_ip.py", line 39, in real_ip_middleware
    return await handler(request)
  File "/usr/src/homeassistant/homeassistant/components/http/ban.py", line 73, in ban_middleware
    return await handler(request)
  File "/usr/src/homeassistant/homeassistant/components/http/auth.py", line 127, in auth_middleware
    return await handler(request)
  File "/usr/src/homeassistant/homeassistant/components/http/view.py", line 129, in handle
    result = await result
  File "/usr/src/homeassistant/homeassistant/components/config/config_entries.py", line 136, in get
    return await super().get(request, flow_id)
  File "/usr/src/homeassistant/homeassistant/helpers/data_entry_flow.py", line 92, in get
    result = await self._flow_mgr.async_configure(flow_id)
  File "/usr/src/homeassistant/homeassistant/data_entry_flow.py", line 153, in async_configure
    result = await self._async_handle_step(flow, cur_step["step_id"], user_input)
  File "/usr/src/homeassistant/homeassistant/data_entry_flow.py", line 201, in _async_handle_step
    result: Dict = await getattr(flow, method)(user_input)
  File "/usr/src/homeassistant/homeassistant/components/homekit_controller/config_flow.py", line 275, in async_step_pair
    discovery = await self.controller.find_ip_by_device_id(self.hkid)
  File "/usr/local/lib/python3.7/site-packages/aiohomekit/controller/controller.py", line 92, in find_ip_by_device_id
    max_seconds=max_seconds, zeroconf_instance=self._zeroconf_instance
TypeError: discover_ip() got an unexpected keyword argument 'zeroconf_instance'
```
