### PR TITLE
Fixes

### DIFF
--- a/aiohomekit/controller/ip/connection.py
+++ b/aiohomekit/controller/ip/connection.py
@@ -246,7 +246,10 @@ class HomeKitConnection:
         if not self._connector:
             return
         self._connector.cancel()
-        await self._connector
+        try:
+            await self._connector
+        except asyncio.CancelledError:
+            pass
         self._connector = None
 
     async def get(self, target):
@@ -476,7 +479,7 @@ class HomeKitConnection:
                 raise
 
             except asyncio.CancelledError:
-                return
+                raise
 
             except HomeKitException:
                 logger.debug(

--- a/aiohomekit/http/response.py
+++ b/aiohomekit/http/response.py
@@ -65,7 +65,7 @@ class HttpResponse(object):
             elif self._state == HttpResponse.STATE_HEADERS:
                 # parse a header line
                 line = line.split(b":", 1)
-                name = line[0].decode()
+                name = line[0].decode().strip().title()
                 value = line[1].decode().strip()
                 if name == "Transfer-Encoding":
                     if value == "chunked":

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,6 +1,6 @@
 #! /bin/sh
 set -e
-
+alias python="poetry run python"
 python -m black tests aiohomekit
 python -m isort -rc tests aiohomekit
 python -m black tests aiohomekit --check --diff

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,6 +38,8 @@ default_section = THIRDPARTY
 known_first_party = aiohomekit,tests
 forced_separate = tests
 combine_as_imports = true
+# force consistent placement of `_socket`
+known_standard_library = _socket
 
 [mypy]
 python_version = 3.7


### PR DESCRIPTION
While trying to get home-assistant to talk to [hap](https://lib.rs/crates/hap), I've so far uncovered two grave issues with this library that I've fixed:

  * aiohomekit's homebrew HTTP parser fails to notice any non-titlecase HTTP headers (this is a spec violation – HTTP headers are case-insensitive)
  * When a connection attempt times out, an asyncio `_reconnect` task will be left spinning in the background

I may update this if I find more issues to be fixed.