### PR TITLE
Load from the zeroconf cache when a ServiceBrowser for _hap is running

### DIFF
--- a/aiohomekit/controller/ip/zeroconf.py
+++ b/aiohomekit/controller/ip/zeroconf.py
@@ -25,4 +25,7 @@ with zeroconf.
 This also means we don't need to add any extra dependencies.
 """
 
-from aiohomekit.zeroconf import async_discover_homekit_devices, discover_homekit_devices  # noqa: F401
+from aiohomekit.zeroconf import (  # noqa: F401
+    async_discover_homekit_devices,
+    discover_homekit_devices,
+)

--- a/aiohomekit/controller/ip/zeroconf.py
+++ b/aiohomekit/controller/ip/zeroconf.py
@@ -25,23 +25,4 @@ with zeroconf.
 This also means we don't need to add any extra dependencies.
 """
 
-import asyncio
-from functools import partial
-
-from zeroconf import Zeroconf
-
-from aiohomekit.zeroconf import discover_homekit_devices
-
-
-async def async_discover_homekit_devices(
-    max_seconds=10, zeroconf_instance: "Zeroconf" = None
-):
-    loop = asyncio.get_event_loop()
-    return await loop.run_in_executor(
-        None,
-        partial(
-            discover_homekit_devices,
-            max_seconds=max_seconds,
-            zeroconf_instance=zeroconf_instance,
-        ),
-    )
+from aiohomekit.zeroconf import async_discover_homekit_devices, discover_homekit_devices  # noqa: F401

--- a/aiohomekit/zeroconf/__init__.py
+++ b/aiohomekit/zeroconf/__init__.py
@@ -297,10 +297,10 @@ def _find_data_for_device_id(
 
 def async_zeroconf_has_hap_service_browser(zeroconf_instance: Zeroconf) -> bool:
     """Check to see if the zeroconf instance has an active HAP ServiceBrowser."""
-    for listener in zeroconf_instance.listeners:
-        if isinstance(listener, ServiceBrowser) and HAP_TYPE in listener.types:
-            return True
-    return False
+    return any(
+        isinstance(listener, ServiceBrowser) and HAP_TYPE in listener.types
+        for listener in zeroconf_instance.listeners
+    )
 
 
 async def async_find_device_ip_and_port(

--- a/aiohomekit/zeroconf/__init__.py
+++ b/aiohomekit/zeroconf/__init__.py
@@ -157,7 +157,9 @@ def get_from_properties(
 
 def _service_info_is_homekit_device(service_info: ServiceInfo) -> bool:
     props = service_info.properties
-    return b"c#" in props and b"md" in props and b"id" in props
+    return (
+        service_info.addresses and b"c#" in props and b"md" in props and b"id" in props
+    )
 
 
 def discover_homekit_devices(

--- a/aiohomekit/zeroconf/__init__.py
+++ b/aiohomekit/zeroconf/__init__.py
@@ -171,9 +171,9 @@ def discover_homekit_devices(
     :param max_seconds: the number of seconds we will wait for the devices to be discovered
     :return: a list of dicts containing all fields as described in table 5.7 page 69
     """
-    zc = zeroconf_instance or Zeroconf()
+    our_zc = zeroconf_instance or Zeroconf()
     listener = CollectingListener()
-    service_browser = ServiceBrowser(zc, HAP_TYPE, listener)
+    service_browser = ServiceBrowser(our_zc, HAP_TYPE, listener)
     sleep(max_seconds)
     tmp = []
     try:
@@ -186,7 +186,7 @@ def discover_homekit_devices(
     finally:
         service_browser.cancel()
         if not zeroconf_instance:
-            zc.close()
+            our_zc.close()
     return tmp
 
 
@@ -269,12 +269,12 @@ def _find_data_for_device_id(
     limit of `max_seconds` before it times out. The runtime of the function may be longer because of the Bonjour
     handling code.
     """
-    zc = zeroconf_instance or Zeroconf()
+    our_zc = zeroconf_instance or Zeroconf()
     found_device_event = threading.Event()
     listener = CollectingListener(
         device_id=device_id, found_device_event=found_device_event
     )
-    service_browser = ServiceBrowser(zc, HAP_TYPE, listener)
+    service_browser = ServiceBrowser(our_zc, HAP_TYPE, listener)
     found_device_event.wait(timeout=max_seconds)
     device_id_bytes = device_id.encode()
 
@@ -288,7 +288,7 @@ def _find_data_for_device_id(
     finally:
         service_browser.cancel()
         if not zeroconf_instance:
-            zc.close()
+            our_zc.close()
 
     raise AccessoryNotFoundError("Device not found via Bonjour within 10 seconds")
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -570,7 +570,7 @@ description = "Pure Python Multicast DNS Service Discovery Library (Bonjour/Avah
 name = "zeroconf"
 optional = false
 python-versions = "*"
-version = "0.28.5"
+version = "0.31.0"
 
 [package.dependencies]
 ifaddr = ">=0.1.7"
@@ -589,8 +589,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "9872d1bc853dcfc4a6b14a2ab66c471e44c17bb3649c3421643cdcb3b98eded5"
-lock-version = "1.0"
+content-hash = "7344e0179df515f94f65803c1eea21f87f10eade6b491d32f6a11bb936b7f497"
 python-versions = "^3.7"
 
 [metadata.files]
@@ -629,7 +628,6 @@ attrs = [
     {file = "attrs-20.2.0.tar.gz", hash = "sha256:26b54ddbbb9ee1d34d5d3668dd37d6cf74990ab23c828c2888dccdceee395594"},
 ]
 black = [
-    {file = "black-20.8b1-py3-none-any.whl", hash = "sha256:70b62ef1527c950db59062cda342ea224d772abdf6adc58b86a45421bab20a6b"},
     {file = "black-20.8b1.tar.gz", hash = "sha256:1c02557aa099101b9d21496f8a914e9ed2222ef70336404eeeac8edba836fbea"},
 ]
 certifi = [
@@ -911,6 +909,7 @@ regex = [
     {file = "regex-2020.7.14-cp38-cp38-manylinux1_i686.whl", hash = "sha256:5ea81ea3dbd6767873c611687141ec7b06ed8bab43f68fad5b7be184a920dc99"},
     {file = "regex-2020.7.14-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:bbb332d45b32df41200380fff14712cb6093b61bd142272a10b16778c418e98e"},
     {file = "regex-2020.7.14-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:c11d6033115dc4887c456565303f540c44197f4fc1a2bfb192224a301534888e"},
+    {file = "regex-2020.7.14-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:75aaa27aa521a182824d89e5ab0a1d16ca207318a6b65042b046053cfc8ed07a"},
     {file = "regex-2020.7.14-cp38-cp38-win32.whl", hash = "sha256:d6cff2276e502b86a25fd10c2a96973fdb45c7a977dca2138d661417f3728341"},
     {file = "regex-2020.7.14-cp38-cp38-win_amd64.whl", hash = "sha256:7a2dd66d2d4df34fa82c9dc85657c5e019b87932019947faece7983f2089a840"},
     {file = "regex-2020.7.14.tar.gz", hash = "sha256:3a3af27a8d23143c49a3420efe5b3f8cf1a48c6fc8bc6856b03f638abc1833bb"},
@@ -990,8 +989,8 @@ yarl = [
     {file = "yarl-1.5.1.tar.gz", hash = "sha256:c22c75b5f394f3d47105045ea551e08a3e804dc7e01b37800ca35b58f856c3d6"},
 ]
 zeroconf = [
-    {file = "zeroconf-0.28.5-py3-none-any.whl", hash = "sha256:f69cc7f9cc3b2a85c7f2cdafe2bb7fb00cf01604bc3df392f7ed5e3c303d7705"},
-    {file = "zeroconf-0.28.5.tar.gz", hash = "sha256:c08dbb90c116626cb6c5f19ebd14cd4846cffe7151f338c19215e6938d334980"},
+    {file = "zeroconf-0.31.0-py3-none-any.whl", hash = "sha256:5a468da018bc3f04bbce77ae247924d802df7aeb4c291bbbb5a9616d128800b0"},
+    {file = "zeroconf-0.31.0.tar.gz", hash = "sha256:53a180248471c6f81bd1fffcbce03ed93d7d8eaf10905c9121ac1ea996d19844"},
 ]
 zipp = [
     {file = "zipp-3.1.0-py3-none-any.whl", hash = "sha256:aa36550ff0c0b7ef7fa639055d797116ee891440eac1a56f378e2d3179e0320b"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 [tool.poetry.dependencies]
 python = "^3.7"
 cryptography = ">=2.9.2"
-zeroconf = {version = ">= 0.28.0"}
+zeroconf = ">=0.31.0"
 
 [tool.poetry.dev-dependencies]
 isort = "^5.4.2"

--- a/tests/accessoryserver.py
+++ b/tests/accessoryserver.py
@@ -143,7 +143,10 @@ class AccessoryServer(ThreadingMixIn, HTTPServer):
             port=self.data.port,
             properties=desc,
         )
-        self.zeroconf.unregister_service(self.zeroconf_info)
+        try:
+            self.zeroconf.unregister_service(self.zeroconf_info)
+        except KeyError:
+            pass
         self.zeroconf.register_service(self.zeroconf_info, allow_name_change=True)
 
     def unpublish_device(self):

--- a/tests/test_zeroconf.py
+++ b/tests/test_zeroconf.py
@@ -51,7 +51,7 @@ async def test_find_no_device(mock_zeroconf):
 
 
 async def test_find_with_device(mock_zeroconf):
-    desc = {b"id": b"00:00:02:00:00:02"}
+    desc = {b"id": b"00:00:02:00:00:02", b"c#": b"1", b"md": b"any"}
     info = ServiceInfo(
         "_hap._tcp.local.",
         "foo1._hap._tcp.local.",


### PR DESCRIPTION
Fixes https://github.com/home-assistant/core/issues/50534
Requires https://github.com/jstasiak/python-zeroconf/pull/356

Since there is a ServiceBrowser already running collecting the records in HomeAssistant everything is now near instant similar to the experience the user would get in the Home app:

![5YOU8qszHl](https://user-images.githubusercontent.com/663432/118151350-267e0400-b3d9-11eb-9406-3c4c1b237466.gif)
