### PR TITLE
Provide reconnect_soon to integrate discovery

### DIFF
--- a/aiohomekit/controller/ip/connection.py
+++ b/aiohomekit/controller/ip/connection.py
@@ -531,6 +531,7 @@ class HomeKitConnection:
         #
         interval = 0.5
 
+        logger.debug("Starting reconnect loop to %s:%s", self.host, self.port)
         while not self.closing:
             try:
                 return await self._connect_once()

--- a/aiohomekit/controller/ip/connection.py
+++ b/aiohomekit/controller/ip/connection.py
@@ -266,8 +266,9 @@ class HomeKitConnection:
             # tries right away
             self._reconnect_wait_task.cancel()
             self._reconnect_wait_task = None
-        else:
-            self._start_connector()
+            return
+        self.closing = False
+        self._start_connector()
 
     async def ensure_connection(self):
         """

--- a/aiohomekit/controller/ip/pairing.py
+++ b/aiohomekit/controller/ip/pairing.py
@@ -40,6 +40,9 @@ from .connection import SecureHomeKitConnection
 logger = logging.getLogger(__name__)
 
 
+EMPTY_EVENT = {}
+
+
 def format_characteristic_list(data):
     tmp = {}
     for c in data["characteristics"]:
@@ -74,8 +77,9 @@ class IpPairing(AbstractPairing):
         self.supports_subscribe = True
 
     def event_received(self, event):
-        event = format_characteristic_list(event)
+        self._callback_listeners(format_characteristic_list(event))
 
+    def _callback_listeners(self, event):
         for listener in self.listeners:
             try:
                 listener(event)
@@ -85,6 +89,9 @@ class IpPairing(AbstractPairing):
     async def connection_made(self, secure):
         if not secure:
             return
+
+        # Let our listeners know the connection is available again
+        self._callback_listeners(EMPTY_EVENT)
 
         if self.subscriptions:
             await self.subscribe(self.subscriptions)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,6 +33,20 @@ def port_ready(port):
     return False
 
 
+def wait_for_port_available(port: int):
+    for i in range(100):
+        if not port_ready(port):
+            break
+        time.sleep(0.1)
+
+
+def wait_for_server_online(port: int):
+    for i in range(100):
+        if port_ready(port):
+            break
+        time.sleep(0.1)
+
+
 @pytest.fixture
 async def controller_and_unpaired_accessory(request, loop):
     config_file = tempfile.NamedTemporaryFile(delete=False)
@@ -55,10 +69,7 @@ async def controller_and_unpaired_accessory(request, loop):
     # Make sure get_id() numbers are stable between tests
     model_mixin.id_counter = 0
 
-    for i in range(100):
-        if port_ready(51842):
-            break
-        time.sleep(0.1)
+    wait_for_port_available(51842)
 
     httpd = AccessoryServer(config_file.name, None)
     accessory = Accessory.create_with_info(
@@ -70,6 +81,8 @@ async def controller_and_unpaired_accessory(request, loop):
 
     t = threading.Thread(target=httpd.serve_forever)
     t.start()
+
+    wait_for_server_online(51842)
 
     controller = Controller()
 
@@ -123,6 +136,8 @@ async def controller_and_paired_accessory(request, loop):
     # Make sure get_id() numbers are stable between tests
     model_mixin.id_counter = 0
 
+    wait_for_port_available(51842)
+
     httpd = AccessoryServer(config_file.name, None)
     accessory = Accessory.create_with_info(
         "Testlicht", "lusiardi.de", "Demoserver", "0001", "0.1"
@@ -133,6 +148,8 @@ async def controller_and_paired_accessory(request, loop):
 
     t = threading.Thread(target=httpd.serve_forever)
     t.start()
+
+    wait_for_server_online(51842)
 
     controller_file = tempfile.NamedTemporaryFile(delete=False)
     controller_file.write(
@@ -154,11 +171,6 @@ async def controller_and_paired_accessory(request, loop):
     controller = Controller()
     controller.load_data(controller_file.name)
     config_file.close()
-
-    for i in range(10):
-        if port_ready(51842):
-            break
-        time.sleep(1)
 
     with mock.patch("aiohomekit.zeroconf._find_data_for_device_id") as find:
         find.return_value = {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,6 +55,11 @@ async def controller_and_unpaired_accessory(request, loop):
     # Make sure get_id() numbers are stable between tests
     model_mixin.id_counter = 0
 
+    for i in range(100):
+        if port_ready(51842):
+            break
+        time.sleep(0.1)
+
     httpd = AccessoryServer(config_file.name, None)
     accessory = Accessory.create_with_info(
         "Testlicht", "lusiardi.de", "Demoserver", "0001", "0.1"
@@ -67,11 +72,6 @@ async def controller_and_unpaired_accessory(request, loop):
     t.start()
 
     controller = Controller()
-
-    for i in range(10):
-        if port_ready(51842):
-            break
-        time.sleep(1)
 
     with mock.patch("aiohomekit.zeroconf._find_data_for_device_id") as find:
         find.return_value = {

--- a/tests/test_ip_pairing.py
+++ b/tests/test_ip_pairing.py
@@ -53,7 +53,7 @@ async def test_reconnect_soon_after_disconnected(pairing):
     await pairing.connection.reconnect_soon()
     await pairing.connection.reconnect_soon()
 
-    await asyncio.wait(pairing.connection._connector, 1)
+    await asyncio.wait_for(pairing.connection._connector, timeout=0.5)
     assert pairing.connection.is_connected
 
     characteristics = await pairing.get_characteristics([(1, 9)])

--- a/tests/test_ip_pairing.py
+++ b/tests/test_ip_pairing.py
@@ -29,6 +29,32 @@ async def test_get_characteristics_after_failure(pairing):
     assert characteristics[(1, 9)] == {"value": False}
 
     pairing.connection.transport.close()
+    await asyncio.sleep(0)
+    assert not pairing.connection.is_connected
+
+    characteristics = await pairing.get_characteristics([(1, 9)])
+
+    assert characteristics[(1, 9)] == {"value": False}
+
+
+async def test_reconnect_soon_after_disconnected(pairing):
+    characteristics = await pairing.get_characteristics([(1, 9)])
+
+    assert characteristics[(1, 9)] == {"value": False}
+
+    assert pairing.connection.is_connected
+
+    pairing.connection.transport.close()
+    await asyncio.sleep(0)
+    assert not pairing.connection.is_connected
+
+    # Ensure we can safely call multiple times
+    await pairing.connection.reconnect_soon()
+    await pairing.connection.reconnect_soon()
+    await pairing.connection.reconnect_soon()
+
+    await pairing.connection._connector
+    assert pairing.connection.is_connected
 
     characteristics = await pairing.get_characteristics([(1, 9)])
 

--- a/tests/test_ip_pairing.py
+++ b/tests/test_ip_pairing.py
@@ -1,5 +1,6 @@
 import asyncio
 from unittest import mock
+
 import pytest
 
 from aiohomekit.protocol.statuscodes import HapStatusCodes

--- a/tests/test_ip_pairing.py
+++ b/tests/test_ip_pairing.py
@@ -53,7 +53,7 @@ async def test_reconnect_soon_after_disconnected(pairing):
     await pairing.connection.reconnect_soon()
     await pairing.connection.reconnect_soon()
 
-    await pairing.connection._connector
+    await asyncio.wait(pairing.connection._connector, 1)
     assert pairing.connection.is_connected
 
     characteristics = await pairing.get_characteristics([(1, 9)])


### PR DESCRIPTION
Provide a `reconnect_soon` function that will reconnect soon by canceling any waits (sleeps) in the reconnect loop or starting a new reconnect attempt.

Send an empty event on reconnect to ensure the consumer of the API knows the device is back online.


Testing Steps:
- Unplug device
- Restart Home Assistant, entity is unavailable
- Open Mac discovery app and home assistant windows near each other
- Watch device appear in discovery app (mdns announcement) and Home Assistant shows the entity available in near real time
- Unplug device, wait 10 minutes (long enough for the mdns ttl to expire), entity device is unavailable
- Open Mac discovery app and home assistant windows near each other
- Watch device appear in discovery app (mdns announcement) and Home Assistant shows the entity available in near real time