### PR TITLE
Track characteristic status

### DIFF
--- a/aiohomekit/controller/ip/discovery.py
+++ b/aiohomekit/controller/ip/discovery.py
@@ -19,7 +19,7 @@ import uuid
 from aiohomekit.exceptions import AlreadyPairedError
 from aiohomekit.model.feature_flags import FeatureFlags
 from aiohomekit.protocol import perform_pair_setup_part1, perform_pair_setup_part2
-from aiohomekit.protocol.statuscodes import HAP_STATUS_CODE_DESCRIPTIONS, to_status_code
+from aiohomekit.protocol.statuscodes import to_status_code
 
 from .connection import HomeKitConnection
 from .pairing import IpPairing
@@ -126,8 +126,8 @@ class IpDiscovery:
 
         raise AlreadyPairedError(
             "Identify failed because: {reason} ({code}).".format(
-                reason=HAP_STATUS_CODE_DESCRIPTIONS[code],
-                code=code,
+                reason=code.description,
+                code=code.value,
             )
         )
 

--- a/aiohomekit/controller/ip/discovery.py
+++ b/aiohomekit/controller/ip/discovery.py
@@ -19,7 +19,7 @@ import uuid
 from aiohomekit.exceptions import AlreadyPairedError
 from aiohomekit.model.feature_flags import FeatureFlags
 from aiohomekit.protocol import perform_pair_setup_part1, perform_pair_setup_part2
-from aiohomekit.protocol.statuscodes import HapStatusCodes
+from aiohomekit.protocol.statuscodes import HAP_STATUS_CODE_DESCRIPTIONS, to_status_code
 
 from .connection import HomeKitConnection
 from .pairing import IpPairing
@@ -122,11 +122,11 @@ class IpDiscovery:
         if not response:
             return True
 
-        code = response["code"]
+        code = to_status_code(response["code"])
 
         raise AlreadyPairedError(
             "Identify failed because: {reason} ({code}).".format(
-                reason=HapStatusCodes[code],
+                reason=HAP_STATUS_CODE_DESCRIPTIONS[code],
                 code=code,
             )
         )

--- a/aiohomekit/controller/ip/pairing.py
+++ b/aiohomekit/controller/ip/pairing.py
@@ -34,7 +34,7 @@ from aiohomekit.http import HttpContentTypes
 from aiohomekit.model.characteristics import CharacteristicsTypes
 from aiohomekit.model.services import ServicesTypes
 from aiohomekit.protocol import error_handler
-from aiohomekit.protocol.statuscodes import HAP_STATUS_CODE_DESCRIPTIONS, to_status_code
+from aiohomekit.protocol.statuscodes import to_status_code
 from aiohomekit.protocol.tlv import TLV
 
 from .connection import SecureHomeKitConnection
@@ -55,7 +55,7 @@ def format_characteristic_list(data):
         if "status" in c and c["status"] == 0:
             del c["status"]
         if "status" in c and c["status"] != 0:
-            c["description"] = HAP_STATUS_CODE_DESCRIPTIONS[to_status_code(c["status"])]
+            c["description"] = to_status_code(c["status"]).description
         tmp[key] = c
     return tmp
 
@@ -276,9 +276,7 @@ class IpPairing(AbstractPairing):
             data = {
                 (d["aid"], d["iid"]): {
                     "status": d["status"],
-                    "description": HAP_STATUS_CODE_DESCRIPTIONS[
-                        to_status_code(d["status"])
-                    ],
+                    "description": to_status_code(d["status"]).description,
                 }
                 for d in response["characteristics"]
             }
@@ -345,9 +343,7 @@ class IpPairing(AbstractPairing):
                 for row in response.get("characteristics", []):
                     status[(row["aid"], row["iid"])] = {
                         "status": row["status"],
-                        "description": HAP_STATUS_CODE_DESCRIPTIONS[
-                            to_status_code(row["status"])
-                        ],
+                        "description": to_status_code(row["status"]).description,
                     }
 
         return status

--- a/aiohomekit/controller/ip/pairing.py
+++ b/aiohomekit/controller/ip/pairing.py
@@ -34,7 +34,7 @@ from aiohomekit.http import HttpContentTypes
 from aiohomekit.model.characteristics import CharacteristicsTypes
 from aiohomekit.model.services import ServicesTypes
 from aiohomekit.protocol import error_handler
-from aiohomekit.protocol.statuscodes import HapStatusCodes
+from aiohomekit.protocol.statuscodes import HAP_STATUS_CODE_DESCRIPTIONS, to_status_code
 from aiohomekit.protocol.tlv import TLV
 
 from .connection import SecureHomeKitConnection
@@ -55,7 +55,7 @@ def format_characteristic_list(data):
         if "status" in c and c["status"] == 0:
             del c["status"]
         if "status" in c and c["status"] != 0:
-            c["description"] = HapStatusCodes[c["status"]]
+            c["description"] = HAP_STATUS_CODE_DESCRIPTIONS[to_status_code(c["status"])]
         tmp[key] = c
     return tmp
 
@@ -276,7 +276,9 @@ class IpPairing(AbstractPairing):
             data = {
                 (d["aid"], d["iid"]): {
                     "status": d["status"],
-                    "description": HapStatusCodes[d["status"]],
+                    "description": HAP_STATUS_CODE_DESCRIPTIONS[
+                        to_status_code(d["status"])
+                    ],
                 }
                 for d in response["characteristics"]
             }
@@ -343,7 +345,9 @@ class IpPairing(AbstractPairing):
                 for row in response.get("characteristics", []):
                     status[(row["aid"], row["iid"])] = {
                         "status": row["status"],
-                        "description": HapStatusCodes[row["status"]],
+                        "description": HAP_STATUS_CODE_DESCRIPTIONS[
+                            to_status_code(row["status"])
+                        ],
                     }
 
         return status

--- a/aiohomekit/enum.py
+++ b/aiohomekit/enum.py
@@ -1,0 +1,34 @@
+#
+# Copyright 2021 aiohomekit team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import enum
+
+
+class EnumWithDescription(enum.Enum):
+    def __new__(cls, *args, **kwds):
+        obj = object.__new__(cls)
+        obj._value_ = args[0]
+        return obj
+
+    def __init__(self, _: str, description: str = None):
+        self.__description = description
+
+    def __str__(self):
+        return str(self.value)
+
+    @property
+    def description(self):
+        return self.__description

--- a/aiohomekit/model/__init__.py
+++ b/aiohomekit/model/__init__.py
@@ -17,6 +17,8 @@
 import json
 from typing import Any, Dict, Iterable, List, Optional
 
+from aiohomekit.protocol.statuscodes import to_status_code
+
 from .categories import Categories
 from .characteristics import (
     Characteristic,
@@ -290,4 +292,4 @@ class Accessories:
                 char.set_value(value["value"])
                 continue
 
-            # Later on also handle error states here.
+            char.status = to_status_code(value.get("status", 0))

--- a/aiohomekit/model/__init__.py
+++ b/aiohomekit/model/__init__.py
@@ -177,6 +177,10 @@ class Accessory:
     def firmware_revision(self):
         return self.accessory_information.value(CharacteristicsTypes.FIRMWARE_REVISION)
 
+    @property
+    def available(self):
+        return all(s.available for s in self.services)
+
     @classmethod
     def create_from_dict(cls, data: Dict[str, Any]) -> "Accessory":
         accessory = cls()
@@ -290,6 +294,5 @@ class Accessories:
 
             if "value" in value:
                 char.set_value(value["value"])
-                continue
 
             char.status = to_status_code(value.get("status", 0))

--- a/aiohomekit/model/characteristics/characteristic.py
+++ b/aiohomekit/model/characteristics/characteristic.py
@@ -138,6 +138,10 @@ class Characteristic:
     def status(self, status: HapStatusCode):
         self._status = status
 
+    @property
+    def available(self) -> bool:
+        return self._status != HapStatusCode.UNABLE_TO_COMMUNICATE
+
     def set_events(self, new_val):
         self.ev = new_val
 

--- a/aiohomekit/model/characteristics/characteristic.py
+++ b/aiohomekit/model/characteristics/characteristic.py
@@ -21,7 +21,7 @@ from distutils.util import strtobool
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
 from aiohomekit.exceptions import CharacteristicPermissionError, FormatError
-from aiohomekit.protocol.statuscodes import HapStatusCodes
+from aiohomekit.protocol.statuscodes import HapStatusCode
 from aiohomekit.protocol.tlv import TLV, TlvParseException
 from aiohomekit.tlv8 import tlv_array
 
@@ -84,6 +84,7 @@ class Characteristic:
         self.valid_values_range = None
 
         self._value = None
+        self._status = HapStatusCode(0)
 
         if CharacteristicPermissions.paired_read not in self.perms:
             return
@@ -128,6 +129,14 @@ class Characteristic:
             return CharacteristicsTypes.get_short(self.type)
         except KeyError:
             return None
+
+    @property
+    def status(self) -> HapStatusCode:
+        return self._status
+
+    @status.setter
+    def status(self, status: HapStatusCode):
+        self._status = status
 
     def set_events(self, new_val):
         self.ev = new_val
@@ -175,7 +184,7 @@ class Characteristic:
             if self.format == CharacteristicFormats.bool:
                 new_val = strtobool(str(new_val))
         except ValueError:
-            raise FormatError(HapStatusCodes.INVALID_VALUE)
+            raise FormatError(HapStatusCode.INVALID_VALUE)
 
         if self.format in [
             CharacteristicFormats.uint64,
@@ -186,9 +195,9 @@ class Characteristic:
             CharacteristicFormats.float,
         ]:
             if self.minValue is not None and new_val < self.minValue:
-                raise FormatError(HapStatusCodes.INVALID_VALUE)
+                raise FormatError(HapStatusCode.INVALID_VALUE)
             if self.maxValue is not None and self.maxValue < new_val:
-                raise FormatError(HapStatusCodes.INVALID_VALUE)
+                raise FormatError(HapStatusCode.INVALID_VALUE)
             if self.minStep is not None:
                 tmp = new_val
 
@@ -198,27 +207,27 @@ class Characteristic:
 
                 # use Decimal to calculate the module because it has not the precision problem as float...
                 if Decimal(str(tmp)) % Decimal(str(self.minStep)) != 0:
-                    raise FormatError(HapStatusCodes.INVALID_VALUE)
+                    raise FormatError(HapStatusCode.INVALID_VALUE)
             if self.valid_values is not None and new_val not in self.valid_values:
-                raise FormatError(HapStatusCodes.INVALID_VALUE)
+                raise FormatError(HapStatusCode.INVALID_VALUE)
             if self.valid_values_range is not None and not (
                 self.valid_values_range[0] <= new_val <= self.valid_values_range[1]
             ):
-                raise FormatError(HapStatusCodes.INVALID_VALUE)
+                raise FormatError(HapStatusCode.INVALID_VALUE)
 
         if self.format == CharacteristicFormats.data:
             try:
                 byte_data = base64.decodebytes(new_val.encode())
             except binascii.Error:
-                raise FormatError(HapStatusCodes.INVALID_VALUE)
+                raise FormatError(HapStatusCode.INVALID_VALUE)
             except Exception:
-                raise FormatError(HapStatusCodes.OUT_OF_RESOURCES)
+                raise FormatError(HapStatusCode.OUT_OF_RESOURCES)
             if self.maxDataLen < len(byte_data):
-                raise FormatError(HapStatusCodes.INVALID_VALUE)
+                raise FormatError(HapStatusCode.INVALID_VALUE)
 
         if self.format == CharacteristicFormats.string:
             if len(new_val) > self.maxLen:
-                raise FormatError(HapStatusCodes.INVALID_VALUE)
+                raise FormatError(HapStatusCode.INVALID_VALUE)
 
         return new_val
 
@@ -232,7 +241,7 @@ class Characteristic:
         :return: the value of the characteristic
         """
         if CharacteristicPermissions.paired_read not in self.perms:
-            raise CharacteristicPermissionError(HapStatusCodes.CANT_READ_WRITE_ONLY)
+            raise CharacteristicPermissionError(HapStatusCode.CANT_READ_WRITE_ONLY)
         return self.value
 
     def to_accessory_and_service_list(self):

--- a/aiohomekit/model/services/service.py
+++ b/aiohomekit/model/services/service.py
@@ -155,3 +155,7 @@ class Service:
             d["linked"] = linked
 
         return d
+
+    @property
+    def available(self) -> bool:
+        return all(c.available for c in self.characteristics)

--- a/aiohomekit/protocol/statuscodes.py
+++ b/aiohomekit/protocol/statuscodes.py
@@ -14,39 +14,29 @@
 # limitations under the License.
 #
 
-import enum
+from aiohomekit.enum import EnumWithDescription
 
 
-class HapStatusCode(enum.Enum):
+class HapStatusCode(EnumWithDescription):
 
-    SUCCESS = 0
-    INSUFFICIENT_PRIVILEGES = -70401
-    UNABLE_TO_COMMUNICATE = -70402
-    RESOURCE_BUSY = -70403
-    CANT_WRITE_READ_ONLY = -70404
-    CANT_READ_WRITE_ONLY = -70405
-    NOTIFICATION_NOT_SUPPORTED = -70406
-    OUT_OF_RESOURCES = -70407
-    TIMED_OUT = -70408
-    RESOURCE_NOT_EXIST = -70409
-    INVALID_VALUE = -70410
-    INSUFFICIENT_AUTH = -70411
-
-
-HAP_STATUS_CODE_DESCRIPTIONS = {
-    HapStatusCode.SUCCESS: "This specifies a success for the request.",
-    HapStatusCode.INSUFFICIENT_PRIVILEGES: "Request denied due to insufficient privileges.",
-    HapStatusCode.UNABLE_TO_COMMUNICATE: "Unable to communicate with requested service, e.g. the power to the accessory was turned off.",
-    HapStatusCode.RESOURCE_BUSY: "Resource is busy, try again.",
-    HapStatusCode.CANT_WRITE_READ_ONLY: "Cannot write to read only characteristic.",
-    HapStatusCode.CANT_READ_WRITE_ONLY: "Cannot read from a write only characteristic.",
-    HapStatusCode.NOTIFICATION_NOT_SUPPORTED: "Notification is not supported for characteristic.",
-    HapStatusCode.OUT_OF_RESOURCES: "Out of resources to process request.",
-    HapStatusCode.TIMED_OUT: "Operation timed out.",
-    HapStatusCode.RESOURCE_NOT_EXIST: "Resource does not exist.",
-    HapStatusCode.INVALID_VALUE: "Accessory received an invalid value in a write request.",
-    HapStatusCode.INSUFFICIENT_AUTH: "Insufficient Authorization.",
-}
+    SUCCESS = 0, "This specifies a success for the request."
+    INSUFFICIENT_PRIVILEGES = -70401, "Request denied due to insufficient privileges."
+    UNABLE_TO_COMMUNICATE = (
+        -70402,
+        "Unable to communicate with requested service, e.g. the power to the accessory was turned off.",
+    )
+    RESOURCE_BUSY = -70403, "Resource is busy, try again."
+    CANT_WRITE_READ_ONLY = -70404, "Cannot write to read only characteristic."
+    CANT_READ_WRITE_ONLY = -70405, "Cannot read from a write only characteristic."
+    NOTIFICATION_NOT_SUPPORTED = (
+        -70406,
+        "Notification is not supported for characteristic.",
+    )
+    OUT_OF_RESOURCES = -70407, "Out of resources to process request."
+    TIMED_OUT = -70408, "Operation timed out."
+    RESOURCE_NOT_EXIST = -70409, "Resource does not exist."
+    INVALID_VALUE = -70410, "Accessory received an invalid value in a write request."
+    INSUFFICIENT_AUTH = -70411, "Insufficient Authorization."
 
 
 def to_status_code(status_code: int) -> HapStatusCode:

--- a/aiohomekit/protocol/statuscodes.py
+++ b/aiohomekit/protocol/statuscodes.py
@@ -14,11 +14,10 @@
 # limitations under the License.
 #
 
+import enum
 
-class _HapStatusCodes:
-    """
-    This data is taken from Table 5-12 HAP Satus Codes on page 80.
-    """
+
+class HapStatusCode(enum.Enum):
 
     SUCCESS = 0
     INSUFFICIENT_PRIVILEGES = -70401
@@ -33,32 +32,27 @@ class _HapStatusCodes:
     INVALID_VALUE = -70410
     INSUFFICIENT_AUTH = -70411
 
-    def __init__(self) -> None:
-        self._codes = {
-            _HapStatusCodes.SUCCESS: "This specifies a success for the request.",
-            _HapStatusCodes.INSUFFICIENT_PRIVILEGES: "Request denied due to insufficient privileges.",
-            _HapStatusCodes.UNABLE_TO_COMMUNICATE: "Unable to communicate with requested service, e.g. the power to the accessory was turned off.",
-            _HapStatusCodes.RESOURCE_BUSY: "Resource is busy, try again.",
-            _HapStatusCodes.CANT_WRITE_READ_ONLY: "Cannot write to read only characteristic.",
-            _HapStatusCodes.CANT_READ_WRITE_ONLY: "Cannot read from a write only characteristic.",
-            _HapStatusCodes.NOTIFICATION_NOT_SUPPORTED: "Notification is not supported for characteristic.",
-            _HapStatusCodes.OUT_OF_RESOURCES: "Out of resources to process request.",
-            _HapStatusCodes.TIMED_OUT: "Operation timed out.",
-            _HapStatusCodes.RESOURCE_NOT_EXIST: "Resource does not exist.",
-            _HapStatusCodes.INVALID_VALUE: "Accessory received an invalid value in a write request.",
-            _HapStatusCodes.INSUFFICIENT_AUTH: "Insufficient Authorization.",
-        }
 
-        self._categories_rev = {self._codes[k]: k for k in self._codes.keys()}
+HAP_STATUS_CODE_DESCRIPTIONS = {
+    HapStatusCode.SUCCESS: "This specifies a success for the request.",
+    HapStatusCode.INSUFFICIENT_PRIVILEGES: "Request denied due to insufficient privileges.",
+    HapStatusCode.UNABLE_TO_COMMUNICATE: "Unable to communicate with requested service, e.g. the power to the accessory was turned off.",
+    HapStatusCode.RESOURCE_BUSY: "Resource is busy, try again.",
+    HapStatusCode.CANT_WRITE_READ_ONLY: "Cannot write to read only characteristic.",
+    HapStatusCode.CANT_READ_WRITE_ONLY: "Cannot read from a write only characteristic.",
+    HapStatusCode.NOTIFICATION_NOT_SUPPORTED: "Notification is not supported for characteristic.",
+    HapStatusCode.OUT_OF_RESOURCES: "Out of resources to process request.",
+    HapStatusCode.TIMED_OUT: "Operation timed out.",
+    HapStatusCode.RESOURCE_NOT_EXIST: "Resource does not exist.",
+    HapStatusCode.INVALID_VALUE: "Accessory received an invalid value in a write request.",
+    HapStatusCode.INSUFFICIENT_AUTH: "Insufficient Authorization.",
+}
 
-    def __getitem__(self, item):
-        # Some HAP implementations return
-        # positive values for error code (myq)
-        item = abs(item) * -1
-        if item in self._codes:
-            return self._codes[item]
 
-        raise KeyError(f"Item {item} not found")
+def to_status_code(status_code: int) -> HapStatusCode:
+    # Some HAP implementations return positive values for error code (myq)
+    status_code = abs(status_code) * -1
+    return HapStatusCode(status_code)
 
 
 class _HapBleStatusCodes:
@@ -97,5 +91,4 @@ class _HapBleStatusCodes:
         raise KeyError(f"Item {item} not found")
 
 
-HapStatusCodes = _HapStatusCodes()
 HapBleStatusCodes = _HapBleStatusCodes()

--- a/tests/accessoryserver.py
+++ b/tests/accessoryserver.py
@@ -49,7 +49,7 @@ from aiohomekit.http import HttpStatusCodes
 from aiohomekit.model import Accessories, Categories
 from aiohomekit.model.characteristics import CharacteristicsTypes
 from aiohomekit.protocol import TLV
-from aiohomekit.protocol.statuscodes import HapStatusCodes
+from aiohomekit.protocol.statuscodes import HapStatusCode
 
 
 def tlv_reorder(tlv_array, preferred_order):
@@ -635,7 +635,7 @@ class AccessoryRequestHandler(BaseHTTPRequestHandler):
                                 {
                                     "aid": aid,
                                     "iid": cid,
-                                    "status": HapStatusCodes.INVALID_VALUE,
+                                    "status": HapStatusCode.INVALID_VALUE.value,
                                 }
                             )
                             errors += 1
@@ -644,7 +644,7 @@ class AccessoryRequestHandler(BaseHTTPRequestHandler):
                                 {
                                     "aid": aid,
                                     "iid": cid,
-                                    "status": HapStatusCodes.CANT_READ_WRITE_ONLY,
+                                    "status": HapStatusCode.CANT_READ_WRITE_ONLY.value,
                                 }
                             )
                             errors += 1
@@ -659,7 +659,7 @@ class AccessoryRequestHandler(BaseHTTPRequestHandler):
                                 {
                                     "aid": aid,
                                     "iid": cid,
-                                    "status": HapStatusCodes.OUT_OF_RESOURCES,
+                                    "status": HapStatusCode.OUT_OF_RESOURCES.value,
                                 }
                             )
                             errors += 1
@@ -687,7 +687,7 @@ class AccessoryRequestHandler(BaseHTTPRequestHandler):
                         {
                             "aid": aid,
                             "iid": cid,
-                            "status": HapStatusCodes.RESOURCE_NOT_EXIST,
+                            "status": HapStatusCode.RESOURCE_NOT_EXIST.value,
                         }
                     )
                     errors += 1
@@ -766,7 +766,7 @@ class AccessoryRequestHandler(BaseHTTPRequestHandler):
                                     {
                                         "aid": aid,
                                         "iid": cid,
-                                        "status": HapStatusCodes.NOTIFICATION_NOT_SUPPORTED,
+                                        "status": HapStatusCode.NOTIFICATION_NOT_SUPPORTED.value,
                                     }
                                 )
 
@@ -781,7 +781,7 @@ class AccessoryRequestHandler(BaseHTTPRequestHandler):
                             try:
                                 if "pw" not in characteristic.perms:
                                     raise CharacteristicPermissionError(
-                                        HapStatusCodes.CANT_WRITE_READ_ONLY
+                                        HapStatusCode.CANT_WRITE_READ_ONLY.value
                                     )
                                 new_val = characteristic.validate_value(
                                     characteristic_to_set["value"]
@@ -796,7 +796,7 @@ class AccessoryRequestHandler(BaseHTTPRequestHandler):
                                     {
                                         "aid": aid,
                                         "iid": cid,
-                                        "status": HapStatusCodes.INVALID_VALUE,
+                                        "status": HapStatusCode.INVALID_VALUE.value,
                                     }
                                 )
                                 errors += 1
@@ -811,7 +811,7 @@ class AccessoryRequestHandler(BaseHTTPRequestHandler):
                                     {
                                         "aid": aid,
                                         "iid": cid,
-                                        "status": HapStatusCodes.OUT_OF_RESOURCES,
+                                        "status": HapStatusCode.OUT_OF_RESOURCES.value,
                                     }
                                 )
                                 errors += 1
@@ -821,7 +821,7 @@ class AccessoryRequestHandler(BaseHTTPRequestHandler):
                     {
                         "aid": aid,
                         "iid": cid,
-                        "status": HapStatusCodes.RESOURCE_NOT_EXIST,
+                        "status": HapStatusCode.RESOURCE_NOT_EXIST.value,
                     }
                 )
                 errors += 1
@@ -844,7 +844,7 @@ class AccessoryRequestHandler(BaseHTTPRequestHandler):
     def _post_identify(self):
         if self.server.data.is_paired:
             result_bytes = json.dumps(
-                {"status": HapStatusCodes.INSUFFICIENT_PRIVILEGES}
+                {"status": HapStatusCode.INSUFFICIENT_PRIVILEGES.value}
             ).encode()
             self.send_response(HttpStatusCodes.BAD_REQUEST)
             self.send_header("Content-Type", "application/hap+json")

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -1,0 +1,20 @@
+from aiohomekit.enum import EnumWithDescription
+
+
+class EnumTest(EnumWithDescription):
+
+    RED = 1, "The colour is red"
+    BLUE = 2, "This colour is blue"
+
+
+def test_value_isnt_tuple():
+    assert EnumTest.RED.value == 1
+
+
+def test_casting():
+    assert EnumTest(1) == EnumTest.RED
+
+
+def test_has_description():
+    assert EnumTest.RED.description == "The colour is red"
+    assert EnumTest(1).description == "The colour is red"

--- a/tests/test_ip_pairing.py
+++ b/tests/test_ip_pairing.py
@@ -3,7 +3,7 @@ from unittest import mock
 
 import pytest
 
-from aiohomekit.protocol.statuscodes import HapStatusCodes
+from aiohomekit.protocol.statuscodes import HapStatusCode
 
 
 async def test_list_accessories(pairing):
@@ -193,7 +193,7 @@ async def test_subscribe_invalid_iid(pairing):
     assert result == {
         (1, 999999): {
             "description": "Resource does not exist.",
-            "status": HapStatusCodes.RESOURCE_NOT_EXIST,
+            "status": HapStatusCode.RESOURCE_NOT_EXIST.value,
         }
     }
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -202,6 +202,33 @@ def test_process_changes_error():
     assert on_char.value is False
     assert on_char.status == HapStatusCode.UNABLE_TO_COMMUNICATE
 
+    accessories.process_changes({(1, 8): {"value": True}})
+    assert on_char.value is True
+    assert on_char.status == HapStatusCode.SUCCESS
+
+
+def test_process_changes_availability():
+    accessories = Accessories.from_file("tests/fixtures/koogeek_ls1.json")
+
+    on_char = accessories.aid(1).characteristics.iid(8)
+
+    assert on_char.available is True
+    assert on_char.service.available is True
+    assert on_char.service.accessory.available is True
+
+    accessories.process_changes(
+        {(1, 8): {"status": HapStatusCode.UNABLE_TO_COMMUNICATE.value}}
+    )
+
+    assert on_char.available is False
+    assert on_char.service.available is False
+    assert on_char.service.accessory.available is False
+
+    accessories.process_changes({(1, 8): {"value": True}})
+    assert on_char.available is True
+    assert on_char.service.available is True
+    assert on_char.service.accessory.available is True
+
 
 def test_valid_vals_preserved():
     a = Accessories.from_file("tests/fixtures/aqara_gateway.json").aid(1)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -40,6 +40,7 @@ from aiohomekit.model.characteristics.structs import (
     VideoConfigConfiguration,
 )
 from aiohomekit.model.services import ServicesTypes
+from aiohomekit.protocol.statuscodes import HapStatusCode
 
 
 def test_hue_bridge():
@@ -185,6 +186,21 @@ def test_process_changes():
     accessories.process_changes({(1, 8): {"value": True}})
 
     assert on_char.value is True
+
+
+def test_process_changes_error():
+    accessories = Accessories.from_file("tests/fixtures/koogeek_ls1.json")
+
+    on_char = accessories.aid(1).characteristics.iid(8)
+    assert on_char.value is False
+    assert on_char.status == HapStatusCode.SUCCESS
+
+    accessories.process_changes(
+        {(1, 8): {"status": HapStatusCode.UNABLE_TO_COMMUNICATE.value}}
+    )
+
+    assert on_char.value is False
+    assert on_char.status == HapStatusCode.UNABLE_TO_COMMUNICATE
 
 
 def test_valid_vals_preserved():

--- a/tests/test_statuscodes.py
+++ b/tests/test_statuscodes.py
@@ -1,9 +1,9 @@
 """Test status codes."""
 
-from aiohomekit.protocol.statuscodes import HapStatusCodes
+from aiohomekit.protocol.statuscodes import HapStatusCode, to_status_code
 
 
 async def test_normalized_statuscodes():
     """Verify we account for quirks in HAP implementations."""
-    assert HapStatusCodes[-70411] == "Insufficient Authorization."
-    assert HapStatusCodes[70411] == "Insufficient Authorization."
+    assert to_status_code(70411) == HapStatusCode.INSUFFICIENT_AUTH
+    assert to_status_code(-70411) == HapStatusCode.INSUFFICIENT_AUTH


### PR DESCRIPTION
This PR tracks the last characteristic state as `Characteristic.status`. This is a `HapStatusCode`, a new enum type that replaces the messier `HapStatusCodes` class. The old code wasn't useful for linting/code completion, the new enum type is.

It also adds a `bool` to `Characteristic`, `Service` and `Accessory` that returns `true` if the last `Characteristic.status` isn't `HapStatusCode.UNABLE_TO_COMMUNICATE`. For `Service` and `Accessory` i'm using `all()` to consider the state of all accessories beneath that `Service`/`Accessory`.

I considered making `available` `true` if `status == HapStatusCode.SUCCESS`, but ultimately couldn't decide if that was better or worse.

This should provide enough information to fix https://github.com/home-assistant/core/issues/51077, and leaves some room for homekit_controller to decide whether just to track the status of the entire accessory (for simplicity) or to track just the characteristics it is polling/subscribed to.

@bdraco do you have any thoughts on this?