### PR TITLE
Better handling of newlines inside http response body

### DIFF
--- a/aiohomekit/controller/ip/pairing.py
+++ b/aiohomekit/controller/ip/pairing.py
@@ -229,7 +229,7 @@ class IpPairing(AbstractPairing):
             await self.list_accessories_and_characteristics()
 
         url = "/characteristics?id=" + ",".join(
-            [str(x[0]) + "." + str(x[1]) for x in characteristics]
+            str(x[0]) + "." + str(x[1]) for x in characteristics
         )
         if include_meta:
             url += "&meta=1"

--- a/tests/accessoryserver.py
+++ b/tests/accessoryserver.py
@@ -412,7 +412,7 @@ class AccessoryRequestHandler(BaseHTTPRequestHandler):
         event = [
             "EVENT/1.0 200 OK",
             "Content-Type: application/hap+json",
-            "Content-Length: {}".format(len(body)),
+            f"Content-Length: {len(body)}",
             "",
             body,
         ]

--- a/tests/test_http_response.py
+++ b/tests/test_http_response.py
@@ -206,7 +206,7 @@ def test_example_lines():
         b"Content-Length: 95\r\n",
         b"Connection: keep-alive\r\n",
         b"\r\n",
-        b'{"characteristics":[{"aid":1,"iid":10,"value":35},'
+        b'{"characteristics":[{"aid":1,"iid":10,"value":35},',
         b'{"aid":1,"iid":13,"value":36.0999984741211}]}',
     ]
     res = parse(parts)
@@ -312,3 +312,22 @@ def test_example_multi_status_3():
         ]
     )
     assert res.code == 207
+
+
+def test_newline_in_payload():
+    parts = [
+        b"HTTP/1.1 200 OK\r\n",
+        b"Content-Type: application/hap+json\r\n",
+        b"Content-Length: 97\r\n",
+        b"Connection: keep-alive\r\n",
+        b"\r\n",
+        b'{"characteristics":[{"aid":1,"iid":10,"value":35},\r\n',
+        b'{"aid":1,"iid":13,"value":36.0999984741211}]}',
+    ]
+    res = parse(parts)
+    assert res.code == 200
+    assert res.get_http_name() == "HTTP"
+    assert (
+        res.body
+        == b'{"characteristics":[{"aid":1,"iid":10,"value":35},\r\n{"aid":1,"iid":13,"value":36.0999984741211}]}'
+    )


### PR DESCRIPTION
As https://github.com/Jc2k/aiohomekit/issues/10 is still not viable, this continues to adapt our internal parsing.

This may be a fix for https://github.com/home-assistant/core/issues/46785.

This is a pretty core part of aiohomekit, changes here could subtly break things for many real world devices. So i've treated lightly. I changed the chunked encoding handling as little as possible while pulling it out of the header parsing code.

## The bug

If there is a new line in the body it hits the bit of code inside the while loop.

```
                if self._content_length > -1:
                    self.body += self._raw_response
                    self._raw_response = bytearray()
```

The blindly appends ALL the remaining buffer, even if content length was 0. Crucially it might take data it doesn't own, corrupting the parser state. The buffer is now empty and it doesn't hit the second code path.

If there isn't a newline it hits the 2nd code path only:

```
            remaining = self._content_length - len(self.body)
            self.body += self._raw_response[:remaining]
            self._raw_response = self._raw_response[remaining:]
```

This tries to drain only enough from the buffer to satisfy the remainder. So this code path works. This creates the erratic behaviour you see in the camera previews.

In addition, the while loop is destructive. Going in there consumes a "line". So we can't go in there if self._state == STATE_BODY. So pull chunked encoding out of that loop.