### PR TITLE
Update to use AsyncZeroconf

### DIFF
--- a/aiohomekit/controller/controller.py
+++ b/aiohomekit/controller/controller.py
@@ -43,14 +43,14 @@ class Controller:
     This class represents a HomeKit controller (normally your iPhone or iPad).
     """
 
-    def __init__(self, ble_adapter: str = "hci0", zeroconf_instance=None) -> None:
+    def __init__(self, ble_adapter: str = "hci0", async_zeroconf_instance=None) -> None:
         """
         Initialize an empty controller. Use 'load_data()' to load the pairing data.
 
         :param ble_adapter: the bluetooth adapter to be used (defaults to hci0)
         """
         self.pairings = {}
-        self._zeroconf_instance = zeroconf_instance
+        self._async_zeroconf_instance = async_zeroconf_instance
         self.ble_adapter = ble_adapter
         self.logger = logging.getLogger(__name__)
 
@@ -83,7 +83,7 @@ class Controller:
         if not IP_TRANSPORT_SUPPORTED:
             raise TransportNotSupportedError("IP")
         devices = await async_discover_homekit_devices(
-            max_seconds, zeroconf_instance=self._zeroconf_instance
+            max_seconds, async_zeroconf_instance=self._async_zeroconf_instance
         )
         tmp = []
         for device in devices:
@@ -96,7 +96,7 @@ class Controller:
         device = await async_find_data_for_device_id(
             device_id=device_id,
             max_seconds=max_seconds,
-            zeroconf_instance=self._zeroconf_instance,
+            async_zeroconf_instance=self._async_zeroconf_instance,
         )
         return IpDiscovery(self, device)
 

--- a/aiohomekit/controller/ip/connection.py
+++ b/aiohomekit/controller/ip/connection.py
@@ -605,7 +605,7 @@ class SecureHomeKitConnection(HomeKitConnection):
         try:
             self.host, self.port = await async_find_device_ip_and_port(
                 self.pairing_data["AccessoryPairingID"],
-                zeroconf_instance=self.owner.controller._zeroconf_instance,
+                async_zeroconf_instance=self.owner.controller._async_zeroconf_instance,
             )
         except AccessoryNotFoundError:
             pass

--- a/aiohomekit/controller/ip/zeroconf.py
+++ b/aiohomekit/controller/ip/zeroconf.py
@@ -27,5 +27,4 @@ This also means we don't need to add any extra dependencies.
 
 from aiohomekit.zeroconf import (  # noqa: F401
     async_discover_homekit_devices,
-    discover_homekit_devices,
 )

--- a/aiohomekit/controller/ip/zeroconf.py
+++ b/aiohomekit/controller/ip/zeroconf.py
@@ -25,6 +25,4 @@ with zeroconf.
 This also means we don't need to add any extra dependencies.
 """
 
-from aiohomekit.zeroconf import (  # noqa: F401
-    async_discover_homekit_devices,
-)
+from aiohomekit.zeroconf import async_discover_homekit_devices  # noqa: F401

--- a/aiohomekit/zeroconf/__init__.py
+++ b/aiohomekit/zeroconf/__init__.py
@@ -20,10 +20,9 @@ from _socket import inet_ntoa
 import asyncio
 import contextlib
 import logging
-import threading
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
-from zeroconf import Error, ServiceBrowser, Zeroconf
+from zeroconf import ServiceBrowser
 from zeroconf.asyncio import AsyncServiceBrowser, AsyncServiceInfo, AsyncZeroconf
 
 from aiohomekit.exceptions import AccessoryNotFoundError
@@ -60,7 +59,7 @@ class CollectingListener:
         """Add a device that became visible via zeroconf."""
         # AsyncServiceInfo already tries 3x
         info = AsyncServiceInfo(zeroconf_type, name)
-        await info.async_request(aiozc.zeroconf, _TIMEOUT_MS)
+        await info.async_request(zeroconf, _TIMEOUT_MS)
         if not _service_info_is_homekit_device(info):
             return
 

--- a/aiohomekit/zeroconf/__init__.py
+++ b/aiohomekit/zeroconf/__init__.py
@@ -60,6 +60,7 @@ class CollectingListener:
         # AsyncServiceInfo already tries 3x
         info = AsyncServiceInfo(zeroconf_type, name)
         await info.async_request(zeroconf, _TIMEOUT_MS)
+
         if not _service_info_is_homekit_device(info):
             return
 

--- a/aiohomekit/zeroconf/__init__.py
+++ b/aiohomekit/zeroconf/__init__.py
@@ -24,8 +24,7 @@ import threading
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 from zeroconf import Error, ServiceBrowser, Zeroconf
-
-from zeroconf.asyncio import AsyncServiceBrowser, AsyncZeroconf, AsyncServiceInfo
+from zeroconf.asyncio import AsyncServiceBrowser, AsyncServiceInfo, AsyncZeroconf
 
 from aiohomekit.exceptions import AccessoryNotFoundError
 from aiohomekit.model import Categories
@@ -273,7 +272,9 @@ async def _async_find_data_for_device_id(
     """
     our_aio_zc = async_zeroconf_instance or AsyncZeroconf()
     found_device_event = asyncio.Event()
-    listener = CollectingListener(device_id=device_id, found_device_event=found_device_event)
+    listener = CollectingListener(
+        device_id=device_id, found_device_event=found_device_event
+    )
     async_service_browser = AsyncServiceBrowser(our_aio_zc, HAP_TYPE, listener)
     with contextlib.suppress(asyncio.TimeoutError):
         await asyncio.wait_for(found_device_event.wait(), timeout=max_seconds)
@@ -299,7 +300,8 @@ def async_zeroconf_has_hap_service_browser(
 ) -> bool:
     """Check to see if the zeroconf instance has an active HAP ServiceBrowser."""
     return any(
-        isinstance(listener, (ServiceBrowser, AsyncServiceBrowser)) and HAP_TYPE in listener.types
+        isinstance(listener, (ServiceBrowser, AsyncServiceBrowser))
+        and HAP_TYPE in listener.types
         for listener in async_zeroconf_instance.zeroconf.listeners
     )
 
@@ -325,4 +327,6 @@ async def async_find_data_for_device_id(
             device_id, async_zeroconf_instance
         )
 
-    await _async_find_data_for_device_id(device_id, max_seconds, async_zeroconf_instance)
+    await _async_find_data_for_device_id(
+        device_id, max_seconds, async_zeroconf_instance
+    )

--- a/aiohomekit/zeroconf/__init__.py
+++ b/aiohomekit/zeroconf/__init__.py
@@ -150,7 +150,7 @@ def get_from_properties(
 
 
 def _service_info_is_homekit_device(service_info: AsyncServiceInfo) -> bool:
-    props = service_info.properties
+    props = {key.lower() for key in service_info.properties.keys()}
     return (
         service_info.addresses and b"c#" in props and b"md" in props and b"id" in props
     )

--- a/aiohomekit/zeroconf/__init__.py
+++ b/aiohomekit/zeroconf/__init__.py
@@ -327,6 +327,6 @@ async def async_find_data_for_device_id(
             device_id, async_zeroconf_instance
         )
 
-    await _async_find_data_for_device_id(
+    return await _async_find_data_for_device_id(
         device_id, max_seconds, async_zeroconf_instance
     )

--- a/poetry.lock
+++ b/poetry.lock
@@ -50,6 +50,14 @@ python-versions = ">=3.5.3"
 version = "3.0.1"
 
 [[package]]
+category = "main"
+description = "Enhance the standard unittest package with features for testing asyncio libraries"
+name = "asynctest"
+optional = false
+python-versions = ">=3.5"
+version = "0.13.0"
+
+[[package]]
 category = "dev"
 description = "Atomic file writes."
 marker = "sys_platform == \"win32\""
@@ -589,7 +597,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "57f6e940a672db63cb458d6a3c88299ae111aca829d96d1912e15a45d255bae3"
+content-hash = "06fbe0e8d7885d06ec994d56adee2c9c83e62ab2aeb16950f76fc14cba1c71f2"
 python-versions = "^3.7"
 
 [metadata.files]
@@ -618,6 +626,10 @@ astroid = [
 async-timeout = [
     {file = "async-timeout-3.0.1.tar.gz", hash = "sha256:0c3c816a028d47f659d6ff5c745cb2acf1f966da1fe5c19c77a70282b25f4c5f"},
     {file = "async_timeout-3.0.1-py3-none-any.whl", hash = "sha256:4291ca197d287d274d0b6cb5d6f8f8f82d434ed288f962539ff18cc9012f9ea3"},
+]
+asynctest = [
+    {file = "asynctest-0.13.0-py3-none-any.whl", hash = "sha256:5da6118a7e6d6b54d83a8f7197769d046922a44d2a99c21382f0a6e4fadae676"},
+    {file = "asynctest-0.13.0.tar.gz", hash = "sha256:c27862842d15d83e6a34eb0b2866c323880eb3a75e4485b079ea11748fd77fac"},
 ]
 atomicwrites = [
     {file = "atomicwrites-1.4.0-py2.py3-none-any.whl", hash = "sha256:6d1784dea7c0c8d4a5172b6c620f40b6e4cbfdf96d783691f2e1302a7b88e197"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -570,7 +570,7 @@ description = "Pure Python Multicast DNS Service Discovery Library (Bonjour/Avah
 name = "zeroconf"
 optional = false
 python-versions = "*"
-version = "0.31.0"
+version = "0.32.0"
 
 [package.dependencies]
 ifaddr = ">=0.1.7"
@@ -589,7 +589,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "7344e0179df515f94f65803c1eea21f87f10eade6b491d32f6a11bb936b7f497"
+content-hash = "57f6e940a672db63cb458d6a3c88299ae111aca829d96d1912e15a45d255bae3"
 python-versions = "^3.7"
 
 [metadata.files]
@@ -989,8 +989,8 @@ yarl = [
     {file = "yarl-1.5.1.tar.gz", hash = "sha256:c22c75b5f394f3d47105045ea551e08a3e804dc7e01b37800ca35b58f856c3d6"},
 ]
 zeroconf = [
-    {file = "zeroconf-0.31.0-py3-none-any.whl", hash = "sha256:5a468da018bc3f04bbce77ae247924d802df7aeb4c291bbbb5a9616d128800b0"},
-    {file = "zeroconf-0.31.0.tar.gz", hash = "sha256:53a180248471c6f81bd1fffcbce03ed93d7d8eaf10905c9121ac1ea996d19844"},
+    {file = "zeroconf-0.32.0-py3-none-any.whl", hash = "sha256:c97c63330a2b9a7a4372eb04c9b9ada3c8ce05f79c0a63771c09577834486ad2"},
+    {file = "zeroconf-0.32.0.tar.gz", hash = "sha256:88130cfe31eb6e4de7c527d47897568db499baa161ef099123ae278c649b2a86"},
 ]
 zipp = [
     {file = "zipp-3.1.0-py3-none-any.whl", hash = "sha256:aa36550ff0c0b7ef7fa639055d797116ee891440eac1a56f378e2d3179e0320b"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -50,7 +50,7 @@ python-versions = ">=3.5.3"
 version = "3.0.1"
 
 [[package]]
-category = "main"
+category = "dev"
 description = "Enhance the standard unittest package with features for testing asyncio libraries"
 name = "asynctest"
 optional = false
@@ -597,7 +597,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "06fbe0e8d7885d06ec994d56adee2c9c83e62ab2aeb16950f76fc14cba1c71f2"
+content-hash = "485468634fa8adefb0a2d5bac4f3df4e0d14e0327e02d2b5db64b4ec6711d52e"
 python-versions = "^3.7"
 
 [metadata.files]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
 python = "^3.7"
 cryptography = ">=2.9.2"
 zeroconf = ">=0.32.0"
+asynctest = "^0.13.0"
 
 [tool.poetry.dev-dependencies]
 isort = "^5.4.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,6 @@ classifiers = [
 python = "^3.7"
 cryptography = ">=2.9.2"
 zeroconf = ">=0.32.0"
-asynctest = "^0.13.0"
 
 [tool.poetry.dev-dependencies]
 isort = "^5.4.2"
@@ -35,6 +34,7 @@ pylint = "^2.4.4"
 pytest-aiohttp = "^0.3.0"
 pyupgrade = "^2.7.2"
 pytest-cov = "^2.10.1"
+asynctest = "^0.13.0"
 
 [tool.black]
 target-version = ["py37", "py38"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 [tool.poetry.dependencies]
 python = "^3.7"
 cryptography = ">=2.9.2"
-zeroconf = ">=0.31.0"
+zeroconf = ">=0.32.0"
 
 [tool.poetry.dev-dependencies]
 isort = "^5.4.2"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -86,7 +86,7 @@ async def controller_and_unpaired_accessory(request, loop):
 
     controller = Controller()
 
-    with mock.patch("aiohomekit.zeroconf._find_data_for_device_id") as find:
+    with mock.patch("aiohomekit.zeroconf._async_find_data_for_device_id") as find:
         find.return_value = {
             "address": "127.0.0.1",
             "port": 51842,
@@ -172,7 +172,7 @@ async def controller_and_paired_accessory(request, loop):
     controller.load_data(controller_file.name)
     config_file.close()
 
-    with mock.patch("aiohomekit.zeroconf._find_data_for_device_id") as find:
+    with mock.patch("aiohomekit.zeroconf._async_find_data_for_device_id") as find:
         find.return_value = {
             "address": "127.0.0.1",
             "port": 51842,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,10 +3,16 @@ import errno
 import logging
 import os
 import socket
+import sys
 import tempfile
 import threading
 import time
 from unittest import mock
+
+if sys.version_info[:2] < (3, 8):
+    from asynctest.mock import patch  # noqa
+else:
+    from unittest.mock import patch  # noqa
 
 import pytest
 
@@ -86,7 +92,7 @@ async def controller_and_unpaired_accessory(request, loop):
 
     controller = Controller()
 
-    with mock.patch("aiohomekit.zeroconf._async_find_data_for_device_id") as find:
+    with patch("aiohomekit.zeroconf._async_find_data_for_device_id") as find:
         find.return_value = {
             "address": "127.0.0.1",
             "port": 51842,
@@ -172,7 +178,7 @@ async def controller_and_paired_accessory(request, loop):
     controller.load_data(controller_file.name)
     config_file.close()
 
-    with mock.patch("aiohomekit.zeroconf._async_find_data_for_device_id") as find:
+    with patch("aiohomekit.zeroconf._async_find_data_for_device_id") as find:
         find.return_value = {
             "address": "127.0.0.1",
             "port": 51842,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -207,7 +207,7 @@ async def pairing(controller_and_paired_accessory):
 
 @pytest.fixture
 async def pairings(request, controller_and_paired_accessory, loop):
-    """ Returns a pairing of pairngs. """
+    """Returns a pairing of pairngs."""
     left = controller_and_paired_accessory.get_pairings()["alias"]
 
     right = IpPairing(left.controller, left.pairing_data)

--- a/tests/test_zeroconf.py
+++ b/tests/test_zeroconf.py
@@ -69,7 +69,9 @@ async def test_find_with_device(mock_asynczeroconf):
 
 
 @pytest.mark.parametrize("exception", [OSError, Error, BadTypeInNameException])
-async def test_find_with_device_async_get_service_info_throws(exception, mock_asynczeroconf):
+async def test_find_with_device_async_get_service_info_throws(
+    exception, mock_asynczeroconf
+):
     mock_asynczeroconf.async_get_service_info.side_effect = exception
 
     with pytest.raises(AccessoryNotFoundError):
@@ -346,7 +348,9 @@ async def test_discover_homekit_devices_shared_zeroconf(mock_asynczeroconf):
     )
     mock_asynczeroconf.async_get_service_info.return_value = info
 
-    result = await async_discover_homekit_devices(max_seconds=0, zeroconf_instance=mock_asynczeroconf)
+    result = await async_discover_homekit_devices(
+        max_seconds=0, zeroconf_instance=mock_asynczeroconf
+    )
 
     assert result == [
         {
@@ -389,7 +393,9 @@ async def test_async_find_data_for_device_id_matches(mock_asynczeroconf):
     mock_asynczeroconf.async_get_service_info.return_value = info
 
     result = await async_find_data_for_device_id(
-        device_id="00:00:01:00:00:02", max_seconds=0, zeroconf_instance=mock_asynczeroconf
+        device_id="00:00:01:00:00:02",
+        max_seconds=0,
+        zeroconf_instance=mock_asynczeroconf,
     )
 
     assert result == {
@@ -465,7 +471,9 @@ async def test_async_find_data_for_device_id_info_without_id(mock_asynczeroconf)
         )
 
 
-async def test_async_find_data_for_device_id_with_active_service_browser(mock_asynczeroconf):
+async def test_async_find_data_for_device_id_with_active_service_browser(
+    mock_asynczeroconf,
+):
     desc = {
         b"c#": b"1",
         b"id": b"00:00:01:00:00:02",

--- a/tests/test_zeroconf.py
+++ b/tests/test_zeroconf.py
@@ -253,47 +253,6 @@ async def test_async_discover_homekit_devices_with_service_browser_running_inval
     assert result == []
 
 
-async def test_async_discover_homekit_devices(mock_asynczeroconf):
-    desc = {
-        b"c#": b"1",
-        b"id": b"00:00:01:00:00:02",
-        b"md": b"unittest",
-        b"s#": b"1",
-        b"ci": b"5",
-        b"sf": b"0",
-    }
-    info = AsyncServiceInfo(
-        "_hap._tcp.local.",
-        "foo2._hap._tcp.local.",
-        addresses=[socket.inet_aton("127.0.0.1")],
-        port=1234,
-        properties=desc,
-        weight=0,
-        priority=0,
-    )
-    with patch("aiohomekit.zeroconf.AsyncServiceInfo", return_value=info):
-        result = await async_discover_homekit_devices(max_seconds=1)
-
-    assert result == [
-        {
-            "address": "127.0.0.1",
-            "c#": "1",
-            "category": "Lightbulb",
-            "ci": "5",
-            "ff": 0,
-            "flags": FeatureFlags(0),
-            "id": "00:00:01:00:00:02",
-            "md": "unittest",
-            "name": "foo2._hap._tcp.local.",
-            "port": 1234,
-            "pv": "1.0",
-            "s#": "1",
-            "sf": "0",
-            "statusflags": "Accessory has been paired.",
-        }
-    ]
-
-
 async def test_discover_homekit_devices_missing_c(mock_asynczeroconf):
     desc = {
         b"id": b"00:00:01:00:00:02",

--- a/tests/test_zeroconf.py
+++ b/tests/test_zeroconf.py
@@ -37,7 +37,7 @@ def mock_asynczeroconf():
     """Mock zeroconf."""
 
     def browser(zeroconf, service, handler):
-        handler.add_service(zeroconf, service, f"name.{service}")
+        handler.add_service(zeroconf.zeroconf, service, f"name.{service}")
         async_browser = MagicMock()
         async_browser.async_cancel = AsyncMock()
         return async_browser
@@ -71,9 +71,8 @@ async def test_find_with_device(mock_asynczeroconf):
         weight=0,
         priority=0,
     )
-    mock_asynczeroconf.async_get_service_info.return_value = info
-
-    result = await async_find_device_ip_and_port("00:00:02:00:00:02", 0)
+    with patch("aiohomekit.zeroconf.AsyncServiceInfo", return_value=info):
+        result = await async_find_device_ip_and_port("00:00:02:00:00:02", 0)
     assert result == ("127.0.0.1", 1234)
 
 
@@ -105,9 +104,8 @@ async def test_async_discover_homekit_devices(mock_asynczeroconf):
         weight=0,
         priority=0,
     )
-    mock_asynczeroconf.async_get_service_info.return_value = info
-
-    result = await async_discover_homekit_devices(max_seconds=0)
+    with patch("aiohomekit.zeroconf.AsyncServiceInfo", return_value=info):
+        result = await async_discover_homekit_devices(max_seconds=0)
 
     assert result == [
         {
@@ -265,9 +263,8 @@ async def test_async_discover_homekit_devices(mock_asynczeroconf):
         weight=0,
         priority=0,
     )
-    mock_asynczeroconf.async_get_service_info.return_value = info
-
-    result = await async_discover_homekit_devices(max_seconds=0)
+    with patch("aiohomekit.zeroconf.AsyncServiceInfo", return_value=info):
+        result = await async_discover_homekit_devices(max_seconds=0)
 
     assert result == [
         {
@@ -306,9 +303,8 @@ async def test_discover_homekit_devices_missing_c(mock_asynczeroconf):
         weight=0,
         priority=0,
     )
-    mock_asynczeroconf.async_get_service_info.return_value = info
-
-    result = await async_discover_homekit_devices(max_seconds=0)
+    with patch("aiohomekit.zeroconf.AsyncServiceInfo", return_value=info):
+        result = await async_discover_homekit_devices(max_seconds=0)
 
     assert result == []
 
@@ -330,9 +326,8 @@ async def test_async_discover_homekit_devices_missing_md(mock_asynczeroconf):
         weight=0,
         priority=0,
     )
-    mock_asynczeroconf.async_get_service_info.return_value = info
-
-    result = await async_discover_homekit_devices(max_seconds=0)
+    with patch("aiohomekit.zeroconf.AsyncServiceInfo", return_value=info):
+        result = await async_discover_homekit_devices(max_seconds=0)
 
     assert result == []
 
@@ -355,11 +350,10 @@ async def test_discover_homekit_devices_shared_zeroconf(mock_asynczeroconf):
         weight=0,
         priority=0,
     )
-    mock_asynczeroconf.async_get_service_info.return_value = info
-
-    result = await async_discover_homekit_devices(
-        max_seconds=0, async_zeroconf_instance=mock_asynczeroconf
-    )
+    with patch("aiohomekit.zeroconf.AsyncServiceInfo", return_value=info):
+        result = await async_discover_homekit_devices(
+            max_seconds=0, async_zeroconf_instance=mock_asynczeroconf
+        )
 
     assert result == [
         {
@@ -399,13 +393,12 @@ async def test_async_find_data_for_device_id_matches(mock_asynczeroconf):
         weight=0,
         priority=0,
     )
-    mock_asynczeroconf.async_get_service_info.return_value = info
-
-    result = await async_find_data_for_device_id(
-        device_id="00:00:01:00:00:02",
-        max_seconds=0,
-        async_zeroconf_instance=mock_asynczeroconf,
-    )
+    with patch("aiohomekit.zeroconf.AsyncServiceInfo", return_value=info):
+        result = await async_find_data_for_device_id(
+            device_id="00:00:01:00:00:02",
+            max_seconds=0,
+            async_zeroconf_instance=mock_asynczeroconf,
+        )
 
     assert result == {
         "address": "127.0.0.1",
@@ -443,14 +436,13 @@ async def test_async_find_data_for_device_id_does_not_match(mock_asynczeroconf):
         weight=0,
         priority=0,
     )
-    mock_asynczeroconf.async_get_service_info.return_value = info
-
-    with pytest.raises(AccessoryNotFoundError):
-        await async_find_data_for_device_id(
-            device_id="00:00:01:00:00:02",
-            max_seconds=0,
-            async_zeroconf_instance=mock_asynczeroconf,
-        )
+    with patch("aiohomekit.zeroconf.AsyncServiceInfo", return_value=info):
+        with pytest.raises(AccessoryNotFoundError):
+            await async_find_data_for_device_id(
+                device_id="00:00:01:00:00:02",
+                max_seconds=0,
+                async_zeroconf_instance=mock_asynczeroconf,
+            )
 
 
 async def test_async_find_data_for_device_id_info_without_id(mock_asynczeroconf):
@@ -470,14 +462,13 @@ async def test_async_find_data_for_device_id_info_without_id(mock_asynczeroconf)
         weight=0,
         priority=0,
     )
-    mock_asynczeroconf.async_get_service_info.return_value = info
-
-    with pytest.raises(AccessoryNotFoundError):
-        await async_find_data_for_device_id(
-            device_id="00:00:01:00:00:02",
-            max_seconds=0,
-            async_zeroconf_instance=mock_asynczeroconf,
-        )
+    with patch("aiohomekit.zeroconf.AsyncServiceInfo", return_value=info):
+        with pytest.raises(AccessoryNotFoundError):
+            await async_find_data_for_device_id(
+                device_id="00:00:01:00:00:02",
+                max_seconds=0,
+                async_zeroconf_instance=mock_asynczeroconf,
+            )
 
 
 async def test_async_find_data_for_device_id_with_active_service_browser(

--- a/tests/test_zeroconf.py
+++ b/tests/test_zeroconf.py
@@ -492,7 +492,7 @@ async def test_async_find_data_for_device_id_with_active_service_browser(
         b"ff": b"3",
         b"sf": b"0",
     }
-    mock_asynczeroconf.cache = MagicMock(
+    mock_asynczeroconf.zeroconf.cache = MagicMock(
         names=MagicMock(return_value=["foo2._hap._tcp.local."])
     )
     with patch(
@@ -543,7 +543,7 @@ async def test_async_find_data_for_device_id_with_active_service_browser_no_matc
         b"ci": b"5",
         b"sf": b"0",
     }
-    mock_asynczeroconf.cache = MagicMock(
+    mock_asynczeroconf.zeroconf.cache = MagicMock(
         names=MagicMock(return_value=["foo2._hap._tcp.local."])
     )
     with patch(

--- a/tests/test_zeroconf.py
+++ b/tests/test_zeroconf.py
@@ -15,7 +15,15 @@
 #
 
 import socket
-from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
+import sys
+from unittest.mock import MagicMock, PropertyMock, patch
+
+if sys.version_info[:2] < (3, 8):
+    from asynctest.mock import CoroutineMock  # noqa
+
+    AsyncMock = CoroutineMock  # noqa: F405
+else:
+    from unittest.mock import AsyncMock  # noqa
 
 import pytest
 from zeroconf import BadTypeInNameException, Error

--- a/tests/test_zeroconf.py
+++ b/tests/test_zeroconf.py
@@ -52,7 +52,8 @@ def mock_asynczeroconf():
             zeroconf = MagicMock()
             zeroconf.async_wait_for_start = AsyncMock()
             zc.zeroconf = zeroconf
-            yield zc            
+            yield zc
+
 
 async def test_find_no_device(mock_asynczeroconf):
     with pytest.raises(AccessoryNotFoundError):
@@ -499,7 +500,8 @@ async def test_async_find_data_for_device_id_with_active_service_browser(
     ), patch(
         "aiohomekit.zeroconf.AsyncServiceInfo.load_from_cache", return_value=True
     ) as mock_load_from_cache, patch(
-        "aiohomekit.zeroconf.AsyncServiceInfo.properties", PropertyMock(return_value=desc)
+        "aiohomekit.zeroconf.AsyncServiceInfo.properties",
+        PropertyMock(return_value=desc),
     ), patch(
         "aiohomekit.zeroconf.AsyncServiceInfo.addresses",
         PropertyMock(return_value=[socket.inet_aton("127.0.0.1")]),
@@ -549,7 +551,8 @@ async def test_async_find_data_for_device_id_with_active_service_browser_no_matc
     ), patch(
         "aiohomekit.zeroconf.AsyncServiceInfo.load_from_cache", return_value=True
     ) as mock_load_from_cache, patch(
-        "aiohomekit.zeroconf.AsyncServiceInfo.properties", PropertyMock(return_value=desc)
+        "aiohomekit.zeroconf.AsyncServiceInfo.properties",
+        PropertyMock(return_value=desc),
     ), patch(
         "aiohomekit.zeroconf.AsyncServiceInfo.addresses",
         PropertyMock(return_value=[socket.inet_aton("127.0.0.1")]),

--- a/tests/test_zeroconf.py
+++ b/tests/test_zeroconf.py
@@ -57,7 +57,7 @@ def mock_asynczeroconf():
 
 async def test_find_no_device(mock_asynczeroconf):
     with pytest.raises(AccessoryNotFoundError):
-        await async_find_device_ip_and_port("00:00:00:00:00:00", 0)
+        await async_find_device_ip_and_port("00:00:00:00:00:00", 1)
 
 
 async def test_find_with_device(mock_asynczeroconf):
@@ -72,7 +72,7 @@ async def test_find_with_device(mock_asynczeroconf):
         priority=0,
     )
     with patch("aiohomekit.zeroconf.AsyncServiceInfo", return_value=info):
-        result = await async_find_device_ip_and_port("00:00:02:00:00:02", 0)
+        result = await async_find_device_ip_and_port("00:00:02:00:00:02", 1)
     assert result == ("127.0.0.1", 1234)
 
 
@@ -80,10 +80,10 @@ async def test_find_with_device(mock_asynczeroconf):
 async def test_find_with_device_async_get_service_info_throws(
     exception, mock_asynczeroconf
 ):
-    mock_asynczeroconf.async_get_service_info.side_effect = exception
-
-    with pytest.raises(AccessoryNotFoundError):
-        await async_find_device_ip_and_port("00:00:02:00:00:02", 0)
+    with patch(
+        "aiohomekit.zeroconf.AsyncServiceInfo", side_effect=exception
+    ), pytest.raises(AccessoryNotFoundError):
+        await async_find_device_ip_and_port("00:00:02:00:00:02", 1)
 
 
 async def test_async_discover_homekit_devices(mock_asynczeroconf):
@@ -105,7 +105,7 @@ async def test_async_discover_homekit_devices(mock_asynczeroconf):
         priority=0,
     )
     with patch("aiohomekit.zeroconf.AsyncServiceInfo", return_value=info):
-        result = await async_discover_homekit_devices(max_seconds=0)
+        result = await async_discover_homekit_devices(max_seconds=1)
 
     assert result == [
         {
@@ -155,7 +155,7 @@ async def test_async_discover_homekit_devices_with_service_browser_running(
         "aiohomekit.zeroconf.async_zeroconf_has_hap_service_browser", return_value=True
     ):
         result = await async_discover_homekit_devices(
-            max_seconds=0, async_zeroconf_instance=mock_asynczeroconf
+            max_seconds=1, async_zeroconf_instance=mock_asynczeroconf
         )
 
     assert result == [
@@ -206,7 +206,7 @@ async def test_async_discover_homekit_devices_with_service_browser_running_not_h
         "aiohomekit.zeroconf.async_zeroconf_has_hap_service_browser", return_value=True
     ):
         result = await async_discover_homekit_devices(
-            max_seconds=0, async_zeroconf_instance=mock_asynczeroconf
+            max_seconds=1, async_zeroconf_instance=mock_asynczeroconf
         )
 
     assert result == []
@@ -239,7 +239,7 @@ async def test_async_discover_homekit_devices_with_service_browser_running_inval
         "aiohomekit.zeroconf.async_zeroconf_has_hap_service_browser", return_value=True
     ):
         result = await async_discover_homekit_devices(
-            max_seconds=0, async_zeroconf_instance=mock_asynczeroconf
+            max_seconds=1, async_zeroconf_instance=mock_asynczeroconf
         )
 
     assert result == []
@@ -264,7 +264,7 @@ async def test_async_discover_homekit_devices(mock_asynczeroconf):
         priority=0,
     )
     with patch("aiohomekit.zeroconf.AsyncServiceInfo", return_value=info):
-        result = await async_discover_homekit_devices(max_seconds=0)
+        result = await async_discover_homekit_devices(max_seconds=1)
 
     assert result == [
         {
@@ -304,7 +304,7 @@ async def test_discover_homekit_devices_missing_c(mock_asynczeroconf):
         priority=0,
     )
     with patch("aiohomekit.zeroconf.AsyncServiceInfo", return_value=info):
-        result = await async_discover_homekit_devices(max_seconds=0)
+        result = await async_discover_homekit_devices(max_seconds=1)
 
     assert result == []
 
@@ -327,7 +327,7 @@ async def test_async_discover_homekit_devices_missing_md(mock_asynczeroconf):
         priority=0,
     )
     with patch("aiohomekit.zeroconf.AsyncServiceInfo", return_value=info):
-        result = await async_discover_homekit_devices(max_seconds=0)
+        result = await async_discover_homekit_devices(max_seconds=1)
 
     assert result == []
 
@@ -352,7 +352,7 @@ async def test_discover_homekit_devices_shared_zeroconf(mock_asynczeroconf):
     )
     with patch("aiohomekit.zeroconf.AsyncServiceInfo", return_value=info):
         result = await async_discover_homekit_devices(
-            max_seconds=0, async_zeroconf_instance=mock_asynczeroconf
+            max_seconds=1, async_zeroconf_instance=mock_asynczeroconf
         )
 
     assert result == [
@@ -396,7 +396,7 @@ async def test_async_find_data_for_device_id_matches(mock_asynczeroconf):
     with patch("aiohomekit.zeroconf.AsyncServiceInfo", return_value=info):
         result = await async_find_data_for_device_id(
             device_id="00:00:01:00:00:02",
-            max_seconds=0,
+            max_seconds=1,
             async_zeroconf_instance=mock_asynczeroconf,
         )
 
@@ -440,7 +440,7 @@ async def test_async_find_data_for_device_id_does_not_match(mock_asynczeroconf):
         with pytest.raises(AccessoryNotFoundError):
             await async_find_data_for_device_id(
                 device_id="00:00:01:00:00:02",
-                max_seconds=0,
+                max_seconds=1,
                 async_zeroconf_instance=mock_asynczeroconf,
             )
 
@@ -466,7 +466,7 @@ async def test_async_find_data_for_device_id_info_without_id(mock_asynczeroconf)
         with pytest.raises(AccessoryNotFoundError):
             await async_find_data_for_device_id(
                 device_id="00:00:01:00:00:02",
-                max_seconds=0,
+                max_seconds=1,
                 async_zeroconf_instance=mock_asynczeroconf,
             )
 
@@ -499,7 +499,7 @@ async def test_async_find_data_for_device_id_with_active_service_browser(
     ):
         result = await async_find_data_for_device_id(
             device_id="00:00:01:00:00:02",
-            max_seconds=0,
+            max_seconds=1,
             async_zeroconf_instance=mock_asynczeroconf,
         )
 
@@ -552,7 +552,7 @@ async def test_async_find_data_for_device_id_with_active_service_browser_no_matc
     ):
         await async_find_data_for_device_id(
             device_id="00:00:01:00:00:02",
-            max_seconds=0,
+            max_seconds=1,
             async_zeroconf_instance=mock_asynczeroconf,
         )
 

--- a/tests/test_zeroconf.py
+++ b/tests/test_zeroconf.py
@@ -148,7 +148,7 @@ async def test_async_discover_homekit_devices_with_service_browser_running(
         priority=0,
     )
 
-    mock_asynczeroconf.cache = MagicMock(
+    mock_asynczeroconf.zeroconf.cache = MagicMock(
         names=MagicMock(return_value=["foo2._hap._tcp.local."])
     )
     with patch("aiohomekit.zeroconf.AsyncServiceInfo", return_value=info), patch(
@@ -199,7 +199,7 @@ async def test_async_discover_homekit_devices_with_service_browser_running_not_h
         priority=0,
     )
 
-    mock_asynczeroconf.cache = MagicMock(
+    mock_asynczeroconf.zeroconf.cache = MagicMock(
         names=MagicMock(return_value=["foo2._nothap._tcp.local."])
     )
     with patch("aiohomekit.zeroconf.AsyncServiceInfo", return_value=info), patch(
@@ -232,7 +232,7 @@ async def test_async_discover_homekit_devices_with_service_browser_running_inval
         priority=0,
     )
 
-    mock_asynczeroconf.cache = MagicMock(
+    mock_asynczeroconf.zeroconf.cache = MagicMock(
         names=MagicMock(return_value=["foo2._hap._tcp.local."])
     )
     with patch("aiohomekit.zeroconf.AsyncServiceInfo", return_value=info), patch(


### PR DESCRIPTION
Needs zeroconf 0.32.0 which should hopefully be released soon.

With zeroconf 0.32.0, a new `AsyncServiceBrowser` has been introduced.  This PR teaches aiohomekit about it so it does not fallback to slow discovery because it only knew about `ServiceBrowser`

This should fix all the inconsistencies with devices that don't provide the A records in the additionals fields when requesting PTRs

Fixes https://github.com/home-assistant/core/issues/51851