### PR TITLE
Exclude _hap._tcp.local. when enumerating the zeroconf cache

### DIFF
--- a/aiohomekit/zeroconf/__init__.py
+++ b/aiohomekit/zeroconf/__init__.py
@@ -85,7 +85,7 @@ async def _async_homekit_devices_from_cache(
     """Return all homekit devices in the cache, updating any missing data as needed."""
     infos = []
     for name in aiozc.zeroconf.cache.names():
-        if not name.endswith(HAP_TYPE):
+        if not name.endswith(HAP_TYPE) or name == HAP_TYPE:
             continue
         infos.append(AsyncServiceInfo(HAP_TYPE, name))
 

--- a/tests/test_zeroconf.py
+++ b/tests/test_zeroconf.py
@@ -16,7 +16,7 @@
 
 import socket
 import sys
-from unittest.mock import MagicMock, PropertyMock, patch
+from unittest.mock import MagicMock, PropertyMock, call, patch
 
 if sys.version_info[:2] < (3, 8):
     from asynctest.mock import CoroutineMock  # noqa
@@ -157,9 +157,11 @@ async def test_async_discover_homekit_devices_with_service_browser_running(
     )
 
     mock_asynczeroconf.zeroconf.cache = MagicMock(
-        names=MagicMock(return_value=["foo2._hap._tcp.local."])
+        names=MagicMock(return_value=["foo2._hap._tcp.local.", "_hap._tcp.local."])
     )
-    with patch("aiohomekit.zeroconf.AsyncServiceInfo", return_value=info), patch(
+    with patch(
+        "aiohomekit.zeroconf.AsyncServiceInfo", return_value=info
+    ) as asyncserviceinfo_mock, patch(
         "aiohomekit.zeroconf.async_zeroconf_has_hap_service_browser", return_value=True
     ):
         result = await async_discover_homekit_devices(
@@ -183,6 +185,10 @@ async def test_async_discover_homekit_devices_with_service_browser_running(
             "sf": "0",
             "statusflags": "Accessory has been paired.",
         }
+    ]
+
+    assert asyncserviceinfo_mock.mock_calls == [
+        call("_hap._tcp.local.", "foo2._hap._tcp.local.")
     ]
 
 


### PR DESCRIPTION
When a ServiceBrowser is running, we check the cache for existing
_hap._tcp.local. entries. The cache enumeration failed to exclude
_hap._tcp.local. itself (service type with no name) which meant
extra unneeded questions for _hap._tcp.local. itself would be asked
along with each NAME._hap._tcp.local. that needed to be refreshed.