### PR TITLE
Ensure the correct zeroconf object is passed to AsyncServiceBrowser

### DIFF
--- a/aiohomekit/zeroconf/__init__.py
+++ b/aiohomekit/zeroconf/__init__.py
@@ -277,7 +277,7 @@ async def _async_find_data_for_device_id(
     listener = CollectingListener(
         device_id=device_id, found_device_event=found_device_event
     )
-    async_service_browser = AsyncServiceBrowser(our_aio_zc, HAP_TYPE, listener)
+    async_service_browser = AsyncServiceBrowser(our_aio_zc.zeroconf, HAP_TYPE, listener)
     with contextlib.suppress(asyncio.TimeoutError):
         await asyncio.wait_for(found_device_event.wait(), timeout=max_seconds)
     device_id_bytes = device_id.encode()

--- a/tests/test_zeroconf.py
+++ b/tests/test_zeroconf.py
@@ -45,7 +45,10 @@ def mock_asynczeroconf():
     """Mock zeroconf."""
 
     def browser(zeroconf, service, handler):
-        handler.add_service(zeroconf.zeroconf, service, f"name.{service}")
+        # Make sure we get the right mocked object
+        if hasattr("zeroconf", "_extract_mock_name"):  # required python 3.7+
+            assert zeroconf._extract_mock_name() == "zeroconf_mock"
+        handler.add_service(zeroconf, service, f"name.{service}")
         async_browser = MagicMock()
         async_browser.async_cancel = AsyncMock()
         return async_browser
@@ -57,7 +60,7 @@ def mock_asynczeroconf():
             zc = mock_zc.return_value
             zc.async_register_service = AsyncMock()
             zc.async_close = AsyncMock()
-            zeroconf = MagicMock()
+            zeroconf = MagicMock(name="zeroconf_mock")
             zeroconf.async_wait_for_start = AsyncMock()
             zc.zeroconf = zeroconf
             yield zc


### PR DESCRIPTION
The async version was being passed instead of the underlying version 🤦 

When I was doing development it worked this way, but I changed it before release for backwards compat and forgot to fix this when I updated the PR, and it just happened to work because MagicMock was a bit too magic and the devices I were testing with were already in the cache.