### PR TITLE
Workaround for https://github.com/home-assistant/core/issues/52680

### DIFF
--- a/aiohomekit/controller/ip/pairing.py
+++ b/aiohomekit/controller/ip/pairing.py
@@ -229,7 +229,7 @@ class IpPairing(AbstractPairing):
             await self.list_accessories_and_characteristics()
 
         url = "/characteristics?id=" + ",".join(
-            str(x[0]) + "." + str(x[1]) for x in characteristics
+            str(x[0]) + "." + str(x[1]) for x in set(characteristics)
         )
         if include_meta:
             url += "&meta=1"

--- a/tests/accessoryserver.py
+++ b/tests/accessoryserver.py
@@ -610,6 +610,13 @@ class AccessoryRequestHandler(BaseHTTPRequestHandler):
 
         result = {"characteristics": []}
 
+        if len(ids) != len(set(ids)):
+            self.log_message(
+                "duplicate iid detected - this breaks some accessories: %s", ids
+            )
+            self.send_response(HttpStatusCodes.BAD_REQUEST)
+            return
+
         errors = 0
         for id_pair in ids:
             id_pair = id_pair.split(".")

--- a/tests/test_ip_pairing.py
+++ b/tests/test_ip_pairing.py
@@ -26,6 +26,11 @@ async def test_get_characteristics(pairing):
     assert characteristics[(1, 9)] == {"value": False}
 
 
+async def test_duplicate_get_characteristics(pairing):
+    characteristics = await pairing.get_characteristics([(1, 9), (1, 9)])
+    assert characteristics[(1, 9)] == {"value": False}
+
+
 async def test_get_characteristics_after_failure(pairing):
     characteristics = await pairing.get_characteristics([(1, 9)])
 


### PR DESCRIPTION
@bdraco - what do you think of this? This is for https://github.com/home-assistant/core/issues/52680. Normally i'd fix this on the HA side. In fact I did at first, but it's kind of hard to test there.

The alternative would be to extend the test helpers to make it easier to check the API calls we make from HA tests.

Or make them throw an error and fail if they were called with poor quality input parameters.