### PR TITLE
Abstract json loading into aiohomekit.hkjson

### DIFF
--- a/aiohomekit/controller/ip/connection.py
+++ b/aiohomekit/controller/ip/connection.py
@@ -18,8 +18,6 @@ import asyncio
 import json
 import logging
 
-import commentjson
-
 from aiohomekit.crypto.chacha20poly1305 import (
     chacha20_aead_decrypt,
     chacha20_aead_encrypt,
@@ -33,6 +31,7 @@ from aiohomekit.exceptions import (
     HttpErrorResponse,
     TimeoutError,
 )
+import aiohomekit.hkjson as hkjson
 from aiohomekit.http import HttpContentTypes
 from aiohomekit.http.response import HttpResponse
 from aiohomekit.protocol import get_session_keys
@@ -317,7 +316,7 @@ class HomeKitConnection:
     async def get_json(self, target):
         response = await self.get(target)
         body = response.body.decode("utf-8")
-        return commentjson.loads(body)
+        return hkjson.loads(body)
 
     async def put(self, target, body, content_type=HttpContentTypes.JSON):
         """
@@ -350,7 +349,7 @@ class HomeKitConnection:
             )
 
         try:
-            parsed = commentjson.loads(decoded)
+            parsed = hkjson.loads(decoded)
         except json.JSONDecodeError:
             self.transport.close()
             raise AccessoryDisconnectedError(
@@ -389,7 +388,7 @@ class HomeKitConnection:
             return {}
 
         try:
-            parsed = commentjson.loads(decoded)
+            parsed = hkjson.loads(decoded)
         except json.JSONDecodeError:
             self.transport.close()
             raise AccessoryDisconnectedError(
@@ -578,7 +577,7 @@ class HomeKitConnection:
             return
 
         try:
-            parsed = commentjson.loads(decoded)
+            parsed = hkjson.loads(decoded)
         except json.JSONDecodeError:
             return
 

--- a/aiohomekit/hkjson.py
+++ b/aiohomekit/hkjson.py
@@ -1,0 +1,38 @@
+#
+# Copyright 2021 aiohomekit team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import json
+
+import commentjson
+
+
+def loads(s):
+    """Load json or fallback to commentjson.
+
+    We try to load the json with built-in json, and
+    if it fails with JSONDecodeError we fallback to
+    the slower but more tolerant commentjson to
+    accomodate devices that use trailing commas
+    in their json since iOS allows it.
+
+    This approach ensures only devices that produce
+    the technically invalid json have to pay the
+    price of the double decode attempt.
+    """
+    try:
+        return json.loads(s)
+    except json.JSONDecodeError:
+        return commentjson.loads(s)

--- a/tests/test_hkjson.py
+++ b/tests/test_hkjson.py
@@ -1,0 +1,29 @@
+#
+# Copyright 2019 aiohomekit team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import aiohomekit.hkjson as hkjson
+
+
+def test_loads_trailing_comma():
+    """Test we can decode with a trailing comma."""
+    result = hkjson.loads(
+        '{"characteristics":[{"aid":10,"iid":12,"value":27.0},{"aid":10,"iid":13,"value":20.5},]}'
+    )
+    assert result == {
+        "characteristics": [
+            {"aid": 10, "iid": 12, "value": 27.0},
+            {"aid": 10, "iid": 13, "value": 20.5},
+        ]
+    }


### PR DESCRIPTION
- We try to use json.loads first and fallback to commentjson
  if we get a decode error to ensure that only devices that
  have the trailing commas have to pay the performance hit.