### PR TITLE
Ignore tlv8 dataclass fields marked with init=False

### DIFF
--- a/aiohomekit/tlv8.py
+++ b/aiohomekit/tlv8.py
@@ -215,6 +215,8 @@ class TLVStruct:
         result = bytearray()
 
         for struct_field in fields(self):
+            if not struct_field.init:
+                continue
             value = getattr(self, struct_field.name)
 
             if value is None:
@@ -241,7 +243,9 @@ class TLVStruct:
 
         # FIXME: Would by good if we could cache this per cls
         # And not rebuild it every time decode() is called
-        tlv_types = {field.metadata["tlv_type"]: field for field in fields(cls)}
+        tlv_types = {
+            field.metadata["tlv_type"]: field for field in fields(cls) if field.init
+        }
 
         for offset, type, length, value in tlv_iterator(encoded_struct):
             if type not in tlv_types:

--- a/tests/test_tlv8.py
+++ b/tests/test_tlv8.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import IntEnum
 
 from aiohomekit.tlv8 import TLVStruct, tlv_entry, u8
@@ -44,6 +44,34 @@ def test_example_2():
     assert result.state == 3
     assert result.certificate == "a" * 300
     assert result.identifier == "hello"
+
+    assert result.encode() == raw
+
+
+def test_ignore_field():
+    @dataclass
+    class DummyStruct(TLVStruct):
+        # fields stored locally for each house boat
+        number_of_residents: u8 = field(init=False, default=1)
+
+        # fields pulled from satellite network
+        sharks_nearby: u8 = tlv_entry(1)
+        days_ago_sharks_ate: u8 = tlv_entry(3)
+        sharks_have_coherent_monochromatic_light_sources: u8 = tlv_entry(5)
+
+        def risk_of_shark_attack(self):
+            return 100  # the old algorithm was incorrect
+
+    raw = b"\x01\x01\xf0" + b"\x03\x01\x00" + b"\x05\x01\x01"
+
+    result = DummyStruct.decode(raw)
+
+    assert result.number_of_residents == 1
+    assert result.sharks_nearby == 240
+    assert result.days_ago_sharks_ate == 0
+    assert result.sharks_have_coherent_monochromatic_light_sources == 1
+
+    result.number_of_residents = 0
 
     assert result.encode() == raw
 


### PR DESCRIPTION
This allows dataclasses to have supporting fields.