### PR TITLE
BLE Pair-Resume

### DIFF
--- a/aiohomekit/controller/coap/connection.py
+++ b/aiohomekit/controller/coap/connection.py
@@ -357,7 +357,7 @@ class CoAPHomeKitConnection:
 
                 request, expected = state_machine.send(payload)
             except StopIteration as result:
-                derive = result.value
+                _, derive = result.value
                 break
             except Exception:
                 # clean up coap context
@@ -366,11 +366,11 @@ class CoAPHomeKitConnection:
                 # re-raise any exception
                 raise
 
-        recv_key = derive("Control-Salt", "Control-Read-Encryption-Key")
+        recv_key = derive(b"Control-Salt", b"Control-Read-Encryption-Key")
         recv_ctx = ChaCha20Poly1305(recv_key)
-        send_key = derive("Control-Salt", "Control-Write-Encryption-Key")
+        send_key = derive(b"Control-Salt", b"Control-Write-Encryption-Key")
         send_ctx = ChaCha20Poly1305(send_key)
-        event_key = derive("Event-Salt", "Event-Read-Encryption-Key")
+        event_key = derive(b"Event-Salt", b"Event-Read-Encryption-Key")
         event_ctx = ChaCha20Poly1305(event_key)
 
         uri = "coap://%s/" % (self.address)

--- a/aiohomekit/controller/ip/connection.py
+++ b/aiohomekit/controller/ip/connection.py
@@ -621,9 +621,9 @@ class SecureHomeKitConnection(HomeKitConnection):
                 request, expected = state_machine.send(response)
             except StopIteration as result:
                 # If the state machine raises a StopIteration then we have session keys
-                derive = result.value
-                c2a_key = derive("Control-Salt", "Control-Write-Encryption-Key")
-                a2c_key = derive("Control-Salt", "Control-Read-Encryption-Key")
+                _, derive = result.value
+                c2a_key = derive(b"Control-Salt", b"Control-Write-Encryption-Key")
+                a2c_key = derive(b"Control-Salt", b"Control-Read-Encryption-Key")
                 break
 
         # Secure session has been negotiated - switch protocol so all future messages are encrypted

--- a/aiohomekit/crypto/hkdf.py
+++ b/aiohomekit/crypto/hkdf.py
@@ -21,12 +21,12 @@ from cryptography.hazmat.primitives.kdf.hkdf import HKDF
 backend = default_backend()
 
 
-def hkdf_derive(input: bytes, salt: str, info: str) -> bytes:
+def hkdf_derive(input: bytes, salt: bytes, info: bytes, length: int = 32) -> bytes:
     hkdf = HKDF(
         algorithm=hashes.SHA512(),
-        length=32,
-        salt=salt.encode(),
-        info=info.encode(),
+        length=length,
+        salt=salt,
+        info=info,
         backend=backend,
     )
     return hkdf.derive(input)

--- a/aiohomekit/protocol/tlv.py
+++ b/aiohomekit/protocol/tlv.py
@@ -105,7 +105,7 @@ class TLV:
     kTLVError_Busy = bytearray(b"\x07")
 
     # Table 6-27 page 116
-    kTLVMethod_Resume = 0x07
+    kTLVMethod_Resume = 0x06
 
     @staticmethod
     def decode_bytes(bs: bytearray | bytes, expected: list[int] | None = None) -> list:

--- a/tests/accessoryserver.py
+++ b/tests/accessoryserver.py
@@ -932,7 +932,7 @@ class AccessoryRequestHandler(BaseHTTPRequestHandler):
 
             # 6) derive session key
             session_key = hkdf_derive(
-                shared_secret, "Pair-Verify-Encrypt-Salt", "Pair-Verify-Encrypt-Info"
+                shared_secret, b"Pair-Verify-Encrypt-Salt", b"Pair-Verify-Encrypt-Info"
             )
             self.server.sessions[self.session_id]["session_key"] = session_key
 
@@ -1027,7 +1027,7 @@ class AccessoryRequestHandler(BaseHTTPRequestHandler):
             shared_secret = self.server.sessions[self.session_id]["shared_secret"]
 
             controller_to_accessory_key = hkdf_derive(
-                shared_secret, "Control-Salt", "Control-Write-Encryption-Key"
+                shared_secret, b"Control-Salt", b"Control-Write-Encryption-Key"
             )
             self.server.sessions[self.session_id][
                 "controller_to_accessory_key"
@@ -1035,7 +1035,7 @@ class AccessoryRequestHandler(BaseHTTPRequestHandler):
             self.server.sessions[self.session_id]["controller_to_accessory_count"] = 0
 
             accessory_to_controller_key = hkdf_derive(
-                shared_secret, "Control-Salt", "Control-Read-Encryption-Key"
+                shared_secret, b"Control-Salt", b"Control-Read-Encryption-Key"
             )
             self.server.sessions[self.session_id][
                 "accessory_to_controller_key"
@@ -1356,8 +1356,8 @@ class AccessoryRequestHandler(BaseHTTPRequestHandler):
 
             session_key = hkdf_derive(
                 SrpServer.to_byte_array(server.get_session_key()),
-                "Pair-Setup-Encrypt-Salt",
-                "Pair-Setup-Encrypt-Info",
+                b"Pair-Setup-Encrypt-Salt",
+                b"Pair-Setup-Encrypt-Info",
             )
             self.server.sessions[self.session_id]["session_key"] = session_key
 
@@ -1449,8 +1449,8 @@ class AccessoryRequestHandler(BaseHTTPRequestHandler):
 
             ios_device_x = hkdf_derive(
                 SrpServer.to_byte_array(shared_secret),
-                "Pair-Setup-Controller-Sign-Salt",
-                "Pair-Setup-Controller-Sign-Info",
+                b"Pair-Setup-Controller-Sign-Salt",
+                b"Pair-Setup-Controller-Sign-Info",
             )
 
             # 4) construct ios_device_info
@@ -1505,8 +1505,8 @@ class AccessoryRequestHandler(BaseHTTPRequestHandler):
             # 2) derive AccessoryX
             accessory_x = hkdf_derive(
                 SrpServer.to_byte_array(shared_secret),
-                "Pair-Setup-Accessory-Sign-Salt",
-                "Pair-Setup-Accessory-Sign-Info",
+                b"Pair-Setup-Accessory-Sign-Salt",
+                b"Pair-Setup-Accessory-Sign-Info",
             )
 
             # 3)

--- a/tests/test_crypto_hkdf.py
+++ b/tests/test_crypto_hkdf.py
@@ -3,7 +3,7 @@ from aiohomekit.crypto import hkdf_derive
 
 def test_derive():
     material = hkdf_derive(
-        b"1" * 32, "Pair-Verify-Encrypt-Salt", "Pair-Verify-Encrypt-Info"
+        b"1" * 32, b"Pair-Verify-Encrypt-Salt", b"Pair-Verify-Encrypt-Info"
     )
 
     assert material == (


### PR DESCRIPTION
The pair resume protocol can restore a session without new ECC computations, significantly speeding up re-connection time.