### PR TITLE
Remove get_characteristic kwargs

### DIFF
--- a/aiohomekit/__main__.py
+++ b/aiohomekit/__main__.py
@@ -213,13 +213,9 @@ async def get_characteristics(args: Namespace) -> bool:
         try:
             data = await pairing.get_characteristics(
                 characteristics,
-                include_meta=args.meta,
-                include_perms=args.perms,
-                include_type=args.type,
-                include_events=args.events,
             )
         except Exception:
-            logging.exception("Error whilst fetching /accessories")
+            logging.exception("Error whilst getting characteristic values")
             return False
 
         # print the data
@@ -502,34 +498,6 @@ async def main(argv: list[str] | None = None) -> None:
         required=True,
         dest="characteristics",
         help="Read characteristics, multiple characteristics can be given by repeating the option",
-    )
-    get_char_parser.add_argument(
-        "-m",
-        action="store_true",
-        required=False,
-        dest="meta",
-        help="read out the meta data for the characteristics as well",
-    )
-    get_char_parser.add_argument(
-        "-p",
-        action="store_true",
-        required=False,
-        dest="perms",
-        help="read out the permissions for the characteristics as well",
-    )
-    get_char_parser.add_argument(
-        "-t",
-        action="store_true",
-        required=False,
-        dest="type",
-        help="read out the types for the characteristics as well",
-    )
-    get_char_parser.add_argument(
-        "-e",
-        action="store_true",
-        required=False,
-        dest="events",
-        help="read out the events for the characteristics as well",
     )
 
     # put_characteristics - set characteristics values

--- a/aiohomekit/controller/ble/pairing.py
+++ b/aiohomekit/controller/ble/pairing.py
@@ -244,10 +244,6 @@ class BlePairing(AbstractPairing):
     async def get_characteristics(
         self,
         characteristics: list[tuple[int, int]],
-        include_meta=False,
-        include_perms=False,
-        include_type=False,
-        include_events=False,
     ) -> dict[tuple[int, int], Any]:
         await self._ensure_connected()
 

--- a/aiohomekit/controller/coap/pairing.py
+++ b/aiohomekit/controller/coap/pairing.py
@@ -93,10 +93,6 @@ class CoAPPairing(AbstractPairing):
     async def get_characteristics(
         self,
         characteristics,
-        include_meta=False,
-        include_perms=False,
-        include_type=False,
-        include_events=False,
     ):
         await self._ensure_connected()
         return await self.connection.read_characteristics(characteristics)

--- a/aiohomekit/controller/ip/pairing.py
+++ b/aiohomekit/controller/ip/pairing.py
@@ -196,10 +196,6 @@ class IpPairing(AbstractPairing):
     async def get_characteristics(
         self,
         characteristics,
-        include_meta=False,
-        include_perms=False,
-        include_type=False,
-        include_events=False,
     ):
         """
         This method is used to get the current readouts of any characteristic of the accessory.
@@ -225,14 +221,6 @@ class IpPairing(AbstractPairing):
         url = "/characteristics?id=" + ",".join(
             str(x[0]) + "." + str(x[1]) for x in set(characteristics)
         )
-        if include_meta:
-            url += "&meta=1"
-        if include_perms:
-            url += "&perms=1"
-        if include_type:
-            url += "&type=1"
-        if include_events:
-            url += "&ev=1"
 
         response = await self.connection.get_json(url)
 

--- a/tests/test_ip_pairing.py
+++ b/tests/test_ip_pairing.py
@@ -118,9 +118,9 @@ async def test_subscribe(pairing):
 
     assert pairing.subscriptions == {(1, 9)}
 
-    characteristics = await pairing.get_characteristics([(1, 9)], include_events=True)
+    characteristics = await pairing.get_characteristics([(1, 9)])
 
-    assert characteristics == {(1, 9): {"ev": True, "value": False}}
+    assert characteristics == {(1, 9): {"value": False}}
 
 
 async def test_unsubscribe(pairing):
@@ -128,17 +128,17 @@ async def test_unsubscribe(pairing):
 
     assert pairing.subscriptions == {(1, 9)}
 
-    characteristics = await pairing.get_characteristics([(1, 9)], include_events=True)
+    characteristics = await pairing.get_characteristics([(1, 9)])
 
-    assert characteristics == {(1, 9): {"ev": True, "value": False}}
+    assert characteristics == {(1, 9): {"value": False}}
 
     await pairing.unsubscribe([(1, 9)])
 
     assert pairing.subscriptions == set()
 
-    characteristics = await pairing.get_characteristics([(1, 9)], include_events=True)
+    characteristics = await pairing.get_characteristics([(1, 9)])
 
-    assert characteristics == {(1, 9): {"ev": False, "value": False}}
+    assert characteristics == {(1, 9): {"value": False}}
 
 
 async def test_dispatcher_connect(pairing):


### PR DESCRIPTION
They aren't use in HA and only IP implements them. They would be annoying to add to BLE, you should just look in the char cache.