### PR TITLE
self.pairings is via hkid not alias

### DIFF
--- a/aiohomekit/__main__.py
+++ b/aiohomekit/__main__.py
@@ -133,7 +133,7 @@ async def discover(args):
 
 async def pair(args):
     async with get_controller(args) as controller:
-        if args.alias in controller.pairings:
+        if args.alias in controller.aliases:
             print(f'"{args.alias}" is a already known alias')
             return False
 
@@ -162,12 +162,12 @@ async def pair(args):
 async def get_accessories(args: Namespace) -> bool:
     async with get_controller(args) as controller:
 
-        if args.alias not in controller.pairings:
+        if args.alias not in controller.aliases:
             print(f'"{args.alias}" is no known alias')
             return False
 
         try:
-            pairing = controller.pairings[args.alias]
+            pairing = controller.aliases[args.alias]
             data = await pairing.list_accessories_and_characteristics()
             controller.save_data(args.file)
         except Exception:
@@ -198,11 +198,11 @@ async def get_accessories(args: Namespace) -> bool:
 async def get_characteristics(args: Namespace) -> bool:
     async with get_controller(args) as controller:
 
-        if args.alias not in controller.pairings:
+        if args.alias not in controller.aliases:
             print(f'"{args.alias}" is no known alias')
             return False
 
-        pairing = controller.pairings[args.alias]
+        pairing = controller.aliases[args.alias]
 
         # convert the command line parameters to the required form
         characteristics = [
@@ -236,12 +236,12 @@ async def get_characteristics(args: Namespace) -> bool:
 async def put_characteristics(args: Namespace) -> bool:
     async with get_controller(args) as controller:
 
-        if args.alias not in controller.pairings:
+        if args.alias not in controller.aliases:
             print(f'"{args.alias}" is no known alias')
             return False
 
         try:
-            pairing = controller.pairings[args.alias]
+            pairing = controller.aliases[args.alias]
 
             # FIXME use Service.build_update
 
@@ -276,12 +276,12 @@ async def put_characteristics(args: Namespace) -> bool:
 
 async def identify(args: Namespace) -> bool:
     async with get_controller(args) as controller:
-        if args.alias not in controller.pairings:
+        if args.alias not in controller.aliases:
             print(f'"{args.alias}" is no known alias')
             return False
 
         try:
-            pairing = controller.pairings[args.alias]
+            pairing = controller.aliases[args.alias]
             await pairing.identify()
         except Exception:
             logging.exception("Unhandled error whilst identifying device")
@@ -292,11 +292,11 @@ async def identify(args: Namespace) -> bool:
 
 async def list_pairings(args: Namespace) -> bool:
     async with get_controller(args) as controller:
-        if args.alias not in controller.pairings:
+        if args.alias not in controller.aliases:
             print(f'"{args.alias}" is no known alias')
             exit(-1)
 
-        pairing = controller.pairings[args.alias]
+        pairing = controller.aliases[args.alias]
         try:
             pairings = await pairing.list_pairings()
         except Exception as e:
@@ -318,11 +318,11 @@ async def list_pairings(args: Namespace) -> bool:
 
 async def remove_pairing(args):
     async with get_controller(args) as controller:
-        if args.alias not in controller.pairings:
+        if args.alias not in controller.aliases:
             print(f'"{args.alias}" is no known alias')
             return False
 
-        pairing = controller.pairings[args.alias]
+        pairing = controller.aliases[args.alias]
         await pairing.remove_pairing(args.controllerPairingId)
         controller.save_data(args.file)
         print(f'Pairing for "{args.alias}" was removed.')
@@ -331,7 +331,7 @@ async def remove_pairing(args):
 
 async def unpair(args):
     async with get_controller(args) as controller:
-        if args.alias not in controller.pairings:
+        if args.alias not in controller.aliases:
             print(f'"{args.alias}" is no known alias')
             return False
 
@@ -343,11 +343,11 @@ async def unpair(args):
 
 async def get_events(args):
     async with get_controller(args) as controller:
-        if args.alias not in controller.pairings:
+        if args.alias not in controller.aliases:
             print(f'"{args.alias}" is no known alias')
             return False
 
-        pairing = controller.pairings[args.alias]
+        pairing = controller.aliases[args.alias]
 
         # convert the command line parameters to the required form
         characteristics = [

--- a/aiohomekit/controller/abstract.py
+++ b/aiohomekit/controller/abstract.py
@@ -36,6 +36,11 @@ class AbstractDescription(Protocol):
 
 
 class AbstractPairing(metaclass=ABCMeta):
+
+    # The current discovery information for this pairing.
+    # This can be used to detect address changes, s# changes, c# changes, etc
+    description: AbstractDescription | None = None
+
     def __init__(self, controller):
         self.controller = controller
         self.listeners = set()
@@ -124,11 +129,13 @@ class AbstractDiscovery(metaclass=ABCMeta):
 
 class AbstractController(metaclass=ABCMeta):
 
-    pairings: dict[str, AbstractPairing]
     discoveries: dict[str, AbstractDiscovery]
+    pairings: dict[str, AbstractPairing]
+    aliases: dict[str, AbstractPairing]
 
     def __init__(self, char_cache: CharacteristicCacheType):
         self.pairings = {}
+        self.aliases = {}
         self.discoveries = {}
 
         self._char_cache = char_cache
@@ -162,4 +169,8 @@ class AbstractController(metaclass=ABCMeta):
 
     @abstractmethod
     async def async_stop(self) -> None:
+        pass
+
+    @abstractmethod
+    def load_pairing(self, alias: str, pairing_data: dict[str, str]) -> AbstractPairing:
         pass

--- a/aiohomekit/controller/ble/controller.py
+++ b/aiohomekit/controller/ble/controller.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import AsyncIterable
+from typing import Any, AsyncIterable
 
 from bleak import BleakScanner
 from bleak.exc import BleakDBusError, BleakError
@@ -20,6 +20,7 @@ logger = logging.getLogger(__name__)
 class BleController(AbstractController):
     discoveries: dict[str, BleDiscovery]
     pairings: dict[str, BlePairing]
+    aliases: dict[str, BlePairing]
 
     _scanner: BleakScanner | None
 
@@ -64,3 +65,17 @@ class BleController(AbstractController):
     async def async_discover(self) -> AsyncIterable[BleDiscovery]:
         for device in self.discoveries.values():
             yield device
+
+    def load_pairing(
+        self, alias: str, pairing_data: dict[str, Any]
+    ) -> BlePairing | None:
+        if pairing_data["Connection"] != "BLE":
+            return None
+
+        if not (hkid := pairing_data.get("AccessoryPairingID")):
+            return None
+
+        pairing = self.pairings[hkid] = BlePairing(self, pairing_data)
+        self.aliases[alias] = pairing
+
+        return pairing

--- a/aiohomekit/controller/coap/controller.py
+++ b/aiohomekit/controller/coap/controller.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from aiohomekit.controller.coap.discovery import CoAPDiscovery
 from aiohomekit.controller.coap.pairing import CoAPPairing
 from aiohomekit.zeroconf import HAP_TYPE_UDP, ZeroconfController
@@ -10,6 +12,21 @@ class CoAPController(ZeroconfController):
     hap_type = HAP_TYPE_UDP
     discoveries: dict[str, CoAPDiscovery]
     pairings: dict[str, CoAPPairing]
+    aliases: dict[str, CoAPPairing]
 
     def _make_discovery(self, discovery) -> CoAPDiscovery:
         return CoAPDiscovery(self, discovery)
+
+    def load_pairing(
+        self, alias: str, pairing_data: dict[str, Any]
+    ) -> CoAPPairing | None:
+        if pairing_data["Connection"] != "CoAP":
+            return None
+
+        if not (hkid := pairing_data.get("AccessoryPairingID")):
+            return None
+
+        pairing = self.pairings[hkid] = CoAPPairing(self, pairing_data)
+        self.aliases[alias] = pairing
+
+        return pairing

--- a/aiohomekit/controller/ip/controller.py
+++ b/aiohomekit/controller/ip/controller.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from aiohomekit.controller.ip.discovery import IpDiscovery
 from aiohomekit.controller.ip.pairing import IpPairing
 from aiohomekit.zeroconf import HAP_TYPE_TCP, ZeroconfController
@@ -13,3 +15,17 @@ class IpController(ZeroconfController):
 
     def _make_discovery(self, discovery) -> IpDiscovery:
         return IpDiscovery(self, discovery)
+
+    def load_pairing(
+        self, alias: str, pairing_data: dict[str, Any]
+    ) -> IpPairing | None:
+        if pairing_data["Connection"] != "IP":
+            return None
+
+        if not (hkid := pairing_data.get("AccessoryPairingID")):
+            return None
+
+        pairing = self.pairings[hkid] = IpPairing(self, pairing_data)
+        self.aliases[alias] = pairing
+
+        return pairing

--- a/aiohomekit/testing.py
+++ b/aiohomekit/testing.py
@@ -90,9 +90,9 @@ class FakeDiscovery(AbstractDiscovery):
             # pairing_data["AccessoryPort"] = self.port
             pairing_data["Connection"] = "Fake"
 
-            obj = self.controller.pairings[alias] = FakePairing(
-                self.controller, pairing_data, self.accessories
-            )
+            obj = FakePairing(self.controller, pairing_data, self.accessories)
+            self.controller.aliases[alias] = obj
+            self.controller.pairings[self.description.id] = obj
             return obj
 
         return finish_pairing
@@ -268,6 +268,7 @@ class FakeController(AbstractController):
     started: bool
     discoveries: dict[str, FakeDiscovery]
     pairings: dict[str, FakePairing]
+    aliases: dict[str, FakePairing]
 
     def __init__(self):
         super().__init__(char_cache=CharacteristicCacheMemory())
@@ -307,9 +308,9 @@ class FakeController(AbstractController):
             raise AccessoryNotFoundError(device_id)
 
     async def remove_pairing(self, alias: str) -> None:
-        del self.pairings[alias]
+        del self.aliases[alias]
 
     def load_pairing(self, alias: str, pairing_data):
         # This assumes a test has already preseed self.pairings with a fake via
         # add_paired_device
-        return self.pairings[alias]
+        return self.aliases[alias]

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -4,7 +4,7 @@ from aiohomekit.exceptions import AuthenticationError
 
 
 async def test_remove_pairing(controller_and_paired_accessory):
-    pairing = controller_and_paired_accessory.pairings["alias"]
+    pairing = controller_and_paired_accessory.aliases["alias"]
 
     # Verify that there is a pairing connected and working
     await pairing.get_characteristics([(1, 9)])


### PR DESCRIPTION
Can now look up known pairings via device id (`controller.pairings`) or via alias (`controller.aliases`).

In Home Asssistant we use the device id as the alias so its a bit of a no-op there.

Each backend tracks its own pairings. Right now a pairing will only be loaded into the backend it was paired with, but this sets the scene for when the top layer is potentially dynamically switching as needed.