### PR TITLE
Support for BLE disconnected events

### DIFF
--- a/aiohomekit/controller/abstract.py
+++ b/aiohomekit/controller/abstract.py
@@ -46,6 +46,9 @@ class AbstractPairing(metaclass=ABCMeta):
         self.listeners = set()
         self.subscriptions = set()
 
+    def _async_description_update(self, description: AbstractDescription | None):
+        self.description = description
+
     @abstractmethod
     async def close(self):
         pass

--- a/aiohomekit/controller/ble/controller.py
+++ b/aiohomekit/controller/ble/controller.py
@@ -33,6 +33,9 @@ class BleController(AbstractController):
         except ValueError:
             return
 
+        if pairing := self.pairings.get(data.id):
+            pairing._async_description_update(data)
+
         if data.id in self.discoveries:
             self.discoveries[data.id]._async_process_advertisement(data)
             return
@@ -75,7 +78,7 @@ class BleController(AbstractController):
         if not (hkid := pairing_data.get("AccessoryPairingID")):
             return None
 
-        pairing = self.pairings[hkid] = BlePairing(self, pairing_data)
+        pairing = self.pairings[hkid.lower()] = BlePairing(self, pairing_data)
         self.aliases[alias] = pairing
 
         return pairing

--- a/aiohomekit/controller/coap/controller.py
+++ b/aiohomekit/controller/coap/controller.py
@@ -26,7 +26,7 @@ class CoAPController(ZeroconfController):
         if not (hkid := pairing_data.get("AccessoryPairingID")):
             return None
 
-        pairing = self.pairings[hkid] = CoAPPairing(self, pairing_data)
+        pairing = self.pairings[hkid.lower()] = CoAPPairing(self, pairing_data)
         self.aliases[alias] = pairing
 
         return pairing

--- a/aiohomekit/controller/controller.py
+++ b/aiohomekit/controller/controller.py
@@ -128,7 +128,7 @@ class Controller(AbstractController):
 
         for transport in self._transports:
             if pairing := transport.load_pairing(alias, pairing_data):
-                self.pairings[pairing_data["AccessoryPairingID"]] = pairing
+                self.pairings[pairing_data["AccessoryPairingID"].lower()] = pairing
                 self.aliases[alias] = pairing
                 return pairing
 

--- a/aiohomekit/controller/ip/controller.py
+++ b/aiohomekit/controller/ip/controller.py
@@ -25,7 +25,7 @@ class IpController(ZeroconfController):
         if not (hkid := pairing_data.get("AccessoryPairingID")):
             return None
 
-        pairing = self.pairings[hkid] = IpPairing(self, pairing_data)
+        pairing = self.pairings[hkid.lower()] = IpPairing(self, pairing_data)
         self.aliases[alias] = pairing
 
         return pairing


### PR DESCRIPTION
BLE HAP has 2 mechanisms for triggering events, connected and disconnected notifications.

Disconnected notifications use a number in the BLE advertising metadata. When that number increments an event has happened. The number won't increment again until the characteristics have been read, and it won't increment while you are connected.

This PR introduces a hook where BLE advertising data can be checked for these kinds of changes.

The disconnected mechanism doesn't tell us which characteristic changed, so we poll and notify on all subscriptions.