### PR TITLE
Use ChaCha20Poly1305Reusable for encryption

### DIFF
--- a/aiohomekit/crypto/__init__.py
+++ b/aiohomekit/crypto/__init__.py
@@ -15,13 +15,13 @@
 #
 
 __all__ = [
-    "chacha20_aead_decrypt",
-    "chacha20_aead_encrypt",
+    "ChaCha20Poly1305Encryptor",
+    "ChaCha20Poly1305Decryptor",
     "hkdf_derive",
     "SrpClient",
     "SrpServer",
 ]
 
-from .chacha20poly1305 import chacha20_aead_decrypt, chacha20_aead_encrypt
+from .chacha20poly1305 import ChaCha20Poly1305Decryptor, ChaCha20Poly1305Encryptor
 from .hkdf import hkdf_derive
 from .srp import SrpClient, SrpServer

--- a/poetry.lock
+++ b/poetry.lock
@@ -122,6 +122,17 @@ python-versions = "*"
 pycparser = "*"
 
 [[package]]
+name = "chacha20poly1305-reuseable"
+version = "0.0.3"
+description = "ChaCha20Poly1305 that is reuseable for asyncio"
+category = "main"
+optional = false
+python-versions = ">=3.7,<4.0"
+
+[package.dependencies]
+cryptography = ">=36.0.2"
+
+[[package]]
 name = "charset-normalizer"
 version = "2.0.11"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
@@ -190,7 +201,7 @@ toml = ["tomli"]
 
 [[package]]
 name = "cryptography"
-version = "36.0.1"
+version = "37.0.2"
 description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
 category = "main"
 optional = false
@@ -205,7 +216,7 @@ docstest = ["pyenchant (>=1.6.11)", "twine (>=1.12.0)", "sphinxcontrib-spelling 
 pep8test = ["black", "flake8", "flake8-import-order", "pep8-naming"]
 sdist = ["setuptools_rust (>=0.11.4)"]
 ssh = ["bcrypt (>=3.1.5)"]
-test = ["pytest (>=6.2.0)", "pytest-cov", "pytest-subtests", "pytest-xdist", "pretend", "iso8601", "pytz", "hypothesis (>=1.11.4,!=3.79.2)"]
+test = ["pytest (>=6.2.0)", "pytest-benchmark", "pytest-cov", "pytest-subtests", "pytest-xdist", "pretend", "iso8601", "pytz", "hypothesis (>=1.11.4,!=3.79.2)"]
 
 [[package]]
 name = "flake8"
@@ -600,7 +611,7 @@ ifaddr = ">=0.1.7"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "6433b98afaa56f4083e0ec0ca35cbc7619a9ad95c8ec345376480bf1aa492735"
+content-hash = "89826435b5565ccc054616f12c3db9bc1646d2db59496ba010e7deab0229edfe"
 
 [metadata.files]
 aiohttp = [
@@ -782,6 +793,10 @@ cffi = [
     {file = "cffi-1.15.0-cp39-cp39-win_amd64.whl", hash = "sha256:3773c4d81e6e818df2efbc7dd77325ca0dcb688116050fb2b3011218eda36139"},
     {file = "cffi-1.15.0.tar.gz", hash = "sha256:920f0d66a896c2d99f0adbb391f990a84091179542c205fa53ce5787aff87954"},
 ]
+chacha20poly1305-reuseable = [
+    {file = "chacha20poly1305-reuseable-0.0.3.tar.gz", hash = "sha256:0b94680636fb76dac3668ab6b1714e0803d557333149bac4dd7fb0b68012ae45"},
+    {file = "chacha20poly1305_reuseable-0.0.3-py3-none-any.whl", hash = "sha256:6836c1980d1c0e40c77e375ac2c3e9b6f9602565dfea3a856e028de8b99f12e4"},
+]
 charset-normalizer = [
     {file = "charset-normalizer-2.0.11.tar.gz", hash = "sha256:98398a9d69ee80548c762ba991a4728bfc3836768ed226b3945908d1a688371c"},
     {file = "charset_normalizer-2.0.11-py3-none-any.whl", hash = "sha256:2842d8f5e82a1f6aa437380934d5e1cd4fcf2003b06fed6940769c164a480a45"},
@@ -813,9 +828,6 @@ coverage = [
     {file = "coverage-6.3-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:2bc85664b06ba42d14bb74d6ddf19d8bfc520cb660561d2d9ce5786ae72f71b5"},
     {file = "coverage-6.3-cp310-cp310-win32.whl", hash = "sha256:27a94db5dc098c25048b0aca155f5fac674f2cf1b1736c5272ba28ead2fc267e"},
     {file = "coverage-6.3-cp310-cp310-win_amd64.whl", hash = "sha256:bde4aeabc0d1b2e52c4036c54440b1ad05beeca8113f47aceb4998bb7471e2c2"},
-    {file = "coverage-6.3-cp311-cp311-macosx_10_14_x86_64.whl", hash = "sha256:509c68c3e2015022aeda03b003dd68fa19987cdcf64e9d4edc98db41cfc45d30"},
-    {file = "coverage-6.3-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:e4ff163602c5c77e7bb4ea81ba5d3b793b4419f8acd296aae149370902cf4e92"},
-    {file = "coverage-6.3-cp311-cp311-win_amd64.whl", hash = "sha256:d1675db48490e5fa0b300f6329ecb8a9a37c29b9ab64fa9c964d34111788ca2d"},
     {file = "coverage-6.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:7eed8459a2b81848cafb3280b39d7d49950d5f98e403677941c752e7e7ee47cb"},
     {file = "coverage-6.3-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1b4285fde5286b946835a1a53bba3ad41ef74285ba9e8013e14b5ea93deaeafc"},
     {file = "coverage-6.3-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a4748349734110fd32d46ff8897b561e6300d8989a494ad5a0a2e4f0ca974fc7"},
@@ -849,26 +861,28 @@ coverage = [
     {file = "coverage-6.3.tar.gz", hash = "sha256:987a84ff98a309994ca77ed3cc4b92424f824278e48e4bf7d1bb79a63cfe2099"},
 ]
 cryptography = [
-    {file = "cryptography-36.0.1-cp36-abi3-macosx_10_10_universal2.whl", hash = "sha256:73bc2d3f2444bcfeac67dd130ff2ea598ea5f20b40e36d19821b4df8c9c5037b"},
-    {file = "cryptography-36.0.1-cp36-abi3-macosx_10_10_x86_64.whl", hash = "sha256:2d87cdcb378d3cfed944dac30596da1968f88fb96d7fc34fdae30a99054b2e31"},
-    {file = "cryptography-36.0.1-cp36-abi3-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:74d6c7e80609c0f4c2434b97b80c7f8fdfaa072ca4baab7e239a15d6d70ed73a"},
-    {file = "cryptography-36.0.1-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:6c0c021f35b421ebf5976abf2daacc47e235f8b6082d3396a2fe3ccd537ab173"},
-    {file = "cryptography-36.0.1-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5d59a9d55027a8b88fd9fd2826c4392bd487d74bf628bb9d39beecc62a644c12"},
-    {file = "cryptography-36.0.1-cp36-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0a817b961b46894c5ca8a66b599c745b9a3d9f822725221f0e0fe49dc043a3a3"},
-    {file = "cryptography-36.0.1-cp36-abi3-manylinux_2_24_x86_64.whl", hash = "sha256:94ae132f0e40fe48f310bba63f477f14a43116f05ddb69d6fa31e93f05848ae2"},
-    {file = "cryptography-36.0.1-cp36-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:7be0eec337359c155df191d6ae00a5e8bbb63933883f4f5dffc439dac5348c3f"},
-    {file = "cryptography-36.0.1-cp36-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:e0344c14c9cb89e76eb6a060e67980c9e35b3f36691e15e1b7a9e58a0a6c6dc3"},
-    {file = "cryptography-36.0.1-cp36-abi3-win32.whl", hash = "sha256:4caa4b893d8fad33cf1964d3e51842cd78ba87401ab1d2e44556826df849a8ca"},
-    {file = "cryptography-36.0.1-cp36-abi3-win_amd64.whl", hash = "sha256:391432971a66cfaf94b21c24ab465a4cc3e8bf4a939c1ca5c3e3a6e0abebdbcf"},
-    {file = "cryptography-36.0.1-pp37-pypy37_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:bb5829d027ff82aa872d76158919045a7c1e91fbf241aec32cb07956e9ebd3c9"},
-    {file = "cryptography-36.0.1-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ebc15b1c22e55c4d5566e3ca4db8689470a0ca2babef8e3a9ee057a8b82ce4b1"},
-    {file = "cryptography-36.0.1-pp37-pypy37_pp73-manylinux_2_24_x86_64.whl", hash = "sha256:596f3cd67e1b950bc372c33f1a28a0692080625592ea6392987dba7f09f17a94"},
-    {file = "cryptography-36.0.1-pp38-pypy38_pp73-macosx_10_10_x86_64.whl", hash = "sha256:30ee1eb3ebe1644d1c3f183d115a8c04e4e603ed6ce8e394ed39eea4a98469ac"},
-    {file = "cryptography-36.0.1-pp38-pypy38_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:ec63da4e7e4a5f924b90af42eddf20b698a70e58d86a72d943857c4c6045b3ee"},
-    {file = "cryptography-36.0.1-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ca238ceb7ba0bdf6ce88c1b74a87bffcee5afbfa1e41e173b1ceb095b39add46"},
-    {file = "cryptography-36.0.1-pp38-pypy38_pp73-manylinux_2_24_x86_64.whl", hash = "sha256:ca28641954f767f9822c24e927ad894d45d5a1e501767599647259cbf030b903"},
-    {file = "cryptography-36.0.1-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:39bdf8e70eee6b1c7b289ec6e5d84d49a6bfa11f8b8646b5b3dfe41219153316"},
-    {file = "cryptography-36.0.1.tar.gz", hash = "sha256:53e5c1dc3d7a953de055d77bef2ff607ceef7a2aac0353b5d630ab67f7423638"},
+    {file = "cryptography-37.0.2-cp36-abi3-macosx_10_10_universal2.whl", hash = "sha256:ef15c2df7656763b4ff20a9bc4381d8352e6640cfeb95c2972c38ef508e75181"},
+    {file = "cryptography-37.0.2-cp36-abi3-macosx_10_10_x86_64.whl", hash = "sha256:3c81599befb4d4f3d7648ed3217e00d21a9341a9a688ecdd615ff72ffbed7336"},
+    {file = "cryptography-37.0.2-cp36-abi3-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:2bd1096476aaac820426239ab534b636c77d71af66c547b9ddcd76eb9c79e004"},
+    {file = "cryptography-37.0.2-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:31fe38d14d2e5f787e0aecef831457da6cec68e0bb09a35835b0b44ae8b988fe"},
+    {file = "cryptography-37.0.2-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:093cb351031656d3ee2f4fa1be579a8c69c754cf874206be1d4cf3b542042804"},
+    {file = "cryptography-37.0.2-cp36-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:59b281eab51e1b6b6afa525af2bd93c16d49358404f814fe2c2410058623928c"},
+    {file = "cryptography-37.0.2-cp36-abi3-manylinux_2_24_x86_64.whl", hash = "sha256:0cc20f655157d4cfc7bada909dc5cc228211b075ba8407c46467f63597c78178"},
+    {file = "cryptography-37.0.2-cp36-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:f8ec91983e638a9bcd75b39f1396e5c0dc2330cbd9ce4accefe68717e6779e0a"},
+    {file = "cryptography-37.0.2-cp36-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:46f4c544f6557a2fefa7ac8ac7d1b17bf9b647bd20b16decc8fbcab7117fbc15"},
+    {file = "cryptography-37.0.2-cp36-abi3-win32.whl", hash = "sha256:731c8abd27693323b348518ed0e0705713a36d79fdbd969ad968fbef0979a7e0"},
+    {file = "cryptography-37.0.2-cp36-abi3-win_amd64.whl", hash = "sha256:471e0d70201c069f74c837983189949aa0d24bb2d751b57e26e3761f2f782b8d"},
+    {file = "cryptography-37.0.2-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a68254dd88021f24a68b613d8c51d5c5e74d735878b9e32cc0adf19d1f10aaf9"},
+    {file = "cryptography-37.0.2-pp37-pypy37_pp73-manylinux_2_24_x86_64.whl", hash = "sha256:a7d5137e556cc0ea418dca6186deabe9129cee318618eb1ffecbd35bee55ddc1"},
+    {file = "cryptography-37.0.2-pp38-pypy38_pp73-macosx_10_10_x86_64.whl", hash = "sha256:aeaba7b5e756ea52c8861c133c596afe93dd716cbcacae23b80bc238202dc023"},
+    {file = "cryptography-37.0.2-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:95e590dd70642eb2079d280420a888190aa040ad20f19ec8c6e097e38aa29e06"},
+    {file = "cryptography-37.0.2-pp38-pypy38_pp73-manylinux_2_24_x86_64.whl", hash = "sha256:1b9362d34363f2c71b7853f6251219298124aa4cc2075ae2932e64c91a3e2717"},
+    {file = "cryptography-37.0.2-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:e53258e69874a306fcecb88b7534d61820db8a98655662a3dd2ec7f1afd9132f"},
+    {file = "cryptography-37.0.2-pp39-pypy39_pp73-macosx_10_10_x86_64.whl", hash = "sha256:1f3bfbd611db5cb58ca82f3deb35e83af34bb8cf06043fa61500157d50a70982"},
+    {file = "cryptography-37.0.2-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:419c57d7b63f5ec38b1199a9521d77d7d1754eb97827bbb773162073ccd8c8d4"},
+    {file = "cryptography-37.0.2-pp39-pypy39_pp73-manylinux_2_24_x86_64.whl", hash = "sha256:dc26bb134452081859aa21d4990474ddb7e863aa39e60d1592800a8865a702de"},
+    {file = "cryptography-37.0.2-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:3b8398b3d0efc420e777c40c16764d6870bcef2eb383df9c6dbb9ffe12c64452"},
+    {file = "cryptography-37.0.2.tar.gz", hash = "sha256:f224ad253cc9cea7568f49077007d2263efa57396a2f2f78114066fd54b5c68e"},
 ]
 flake8 = [
     {file = "flake8-4.0.1-py2.py3-none-any.whl", hash = "sha256:479b1304f72536a55948cb40a32dce8bb0ffe3501e26eaf292c7e60eb5e0428d"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ python = "^3.9"
 cryptography = ">=2.9.2"
 zeroconf = ">=0.32.0"
 commentjson = "^0.9.0"
+chacha20poly1305-reuseable = "^0.0.3"
 
 [tool.poetry.dev-dependencies]
 isort = "^5.10.1"

--- a/tests/accessoryserver.py
+++ b/tests/accessoryserver.py
@@ -33,8 +33,8 @@ from zeroconf import ServiceInfo, Zeroconf
 
 from aiohomekit.crypto import hkdf_derive
 from aiohomekit.crypto.chacha20poly1305 import (
-    chacha20_aead_decrypt,
-    chacha20_aead_encrypt,
+    ChaCha20Poly1305Decryptor,
+    ChaCha20Poly1305Encryptor,
 )
 from aiohomekit.crypto.srp import SrpServer
 from aiohomekit.exceptions import (
@@ -439,8 +439,8 @@ class AccessoryRequestHandler(BaseHTTPRequestHandler):
                 cnt_bytes = self.server.sessions[self.session_id][
                     "accessory_to_controller_count"
                 ].to_bytes(8, byteorder="little")
-                ciper_and_mac = chacha20_aead_encrypt(
-                    len_bytes, a2c_key, cnt_bytes, bytes([0, 0, 0, 0]), block
+                ciper_and_mac = ChaCha20Poly1305Encryptor(a2c_key).encrypt(
+                    len_bytes, cnt_bytes, bytes([0, 0, 0, 0]), block
                 )
                 self.server.sessions[self.session_id][
                     "accessory_to_controller_count"
@@ -520,8 +520,8 @@ class AccessoryRequestHandler(BaseHTTPRequestHandler):
         cnt_bytes = self.server.sessions[self.session_id][
             "controller_to_accessory_count"
         ].to_bytes(8, byteorder="little")
-        decrypted = chacha20_aead_decrypt(
-            len_bytes, c2a_key, cnt_bytes, bytes([0, 0, 0, 0]), data
+        decrypted = ChaCha20Poly1305Decryptor(c2a_key).decrypt(
+            len_bytes, cnt_bytes, bytes([0, 0, 0, 0]), data
         )
         if decrypted is False:
             # crypto error, log it and request close of connection
@@ -941,9 +941,10 @@ class AccessoryRequestHandler(BaseHTTPRequestHandler):
             self.server.sessions[self.session_id]["session_key"] = session_key
 
             # 7) encrypt sub tlv
-            encrypted_data_with_auth_tag = chacha20_aead_encrypt(
+            encrypted_data_with_auth_tag = ChaCha20Poly1305Encryptor(
+                session_key
+            ).encrypt(
                 bytes(),
-                session_key,
                 b"PV-Msg02",
                 bytes([0, 0, 0, 0]),
                 sub_tlv_b,
@@ -974,9 +975,8 @@ class AccessoryRequestHandler(BaseHTTPRequestHandler):
             # 1) verify ios' authtag
             # 2) decrypt
             encrypted = d_req[1][1]
-            decrypted = chacha20_aead_decrypt(
+            decrypted = ChaCha20Poly1305Decryptor(session_key).decrypt(
                 bytes(),
-                session_key,
                 b"PV-Msg03",
                 bytes([0, 0, 0, 0]),
                 encrypted,
@@ -1419,9 +1419,10 @@ class AccessoryRequestHandler(BaseHTTPRequestHandler):
 
             # 2) decrypt and test
             encrypted_data = d_req[1][1]
-            decrypted_data = chacha20_aead_decrypt(
+            decrypted_data = ChaCha20Poly1305Decryptor(
+                self.server.sessions[self.session_id]["session_key"]
+            ).decrypt(
                 bytes(),
-                self.server.sessions[self.session_id]["session_key"],
                 b"PS-Msg05",
                 bytes([0, 0, 0, 0]),
                 encrypted_data,
@@ -1532,9 +1533,10 @@ class AccessoryRequestHandler(BaseHTTPRequestHandler):
             sub_tlv_b = TLV.encode_list(sub_tlv)
 
             # 6) encrypt sub_tlv
-            encrypted_data_with_auth_tag = chacha20_aead_encrypt(
+            encrypted_data_with_auth_tag = ChaCha20Poly1305Encryptor(
+                self.server.sessions[self.session_id]["session_key"]
+            ).encrypt(
                 bytes(),
-                self.server.sessions[self.session_id]["session_key"],
                 b"PS-Msg06",
                 bytes([0, 0, 0, 0]),
                 sub_tlv_b,

--- a/tests/test_crypto_chacha20poly1305.py
+++ b/tests/test_crypto_chacha20poly1305.py
@@ -15,8 +15,8 @@
 #
 
 from aiohomekit.crypto.chacha20poly1305 import (
-    chacha20_aead_decrypt,
-    chacha20_aead_encrypt,
+    ChaCha20Poly1305Decryptor,
+    ChaCha20Poly1305Encryptor,
 )
 
 
@@ -173,11 +173,14 @@ def test_example2_8_2():
         ),
     )
 
-    r = chacha20_aead_encrypt(aad, key, iv, fixed, plain_text)
+    r = ChaCha20Poly1305Encryptor(key).encrypt(aad, iv, fixed, plain_text)
     assert r[:-16] == r_[0], "ciphertext"
     assert r[-16:] == r_[1], "tag"
 
-    plain_text_ = chacha20_aead_decrypt(aad, key, iv, fixed, r)
+    plain_text_ = ChaCha20Poly1305Decryptor(key).decrypt(aad, iv, fixed, r)
     assert plain_text == plain_text_
 
-    assert chacha20_aead_decrypt(aad, key, iv, fixed, r + bytes([0, 1, 2, 3])) is False
+    assert (
+        ChaCha20Poly1305Decryptor(key).decrypt(aad, iv, fixed, r + bytes([0, 1, 2, 3]))
+        is False
+    )


### PR DESCRIPTION
I built this for the other side of the house since I was annoyed at how long it took my phone to switch over from Mobile to WiFi and wanted to decrease the latency. It also seems to fix the Home app stalling out on iOS 16 betas when using them with Home Assistant's HomeKit integration.

- ChaCha20Poly1305 recreates the ctx every time its called which
  is an expensive operation. This makes quite a bit of difference
  when encrypting large blocks of data (camera images) since each
  block had to create a new context. cryptography does this because
  it needs calls to ChaCha20Poly1305 to be threadsafe at the cost
  of performance. Since we are using asyncio we can avoid the
  overhead of recreating the context every time since the encryptor
  and decryptor are never called from different threads