### PR TITLE
Fix decoding kTLVHAPParamGATTUserDescriptionDescriptor

### DIFF
--- a/aiohomekit/controller/ble/structs.py
+++ b/aiohomekit/controller/ble/structs.py
@@ -100,6 +100,9 @@ class Characteristic(TLVStruct):
     )
     service_instance_id: bytes = tlv_entry(HAP_TLV.kTLVHAPParamServiceInstanceId)
     service_type: bytes = tlv_entry(HAP_TLV.kTLVHAPParamServiceType)
+    user_description: bytes = tlv_entry(
+        HAP_TLV.kTLVHAPParamGATTUserDescriptionDescriptor
+    )
 
     @property
     def supports_read(self) -> bool:


### PR DESCRIPTION
Fixes
```
022-07-16 11:37:53.464 ERROR (MainThread) [homeassistant.components.homekit_controller.config_flow] Pairing attempt failed with an unhandled exception
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/components/homekit_controller/config_flow.py", line 372, in async_step_pair
    return await self._entry_from_accessory(pairing)
  File "/usr/src/homeassistant/homeassistant/components/homekit_controller/config_flow.py", line 484, in _entry_from_accessory
    name = await pairing.get_primary_name()
  File "/usr/local/lib/python3.10/site-packages/aiohomekit/controller/abstract.py", line 115, in get_primary_name
    accessories = await self.list_accessories_and_characteristics()
  File "/usr/local/lib/python3.10/site-packages/aiohomekit/controller/ble/pairing.py", line 86, in _async_wrap
    return await func(self, *args, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/aiohomekit/controller/ble/client.py", line 63, in _async_wrap
    return await func(*args, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/aiohomekit/controller/ble/pairing.py", line 407, in list_accessories_and_characteristics
    await self._populate_accessories_and_characteristics()
  File "/usr/local/lib/python3.10/site-packages/aiohomekit/controller/ble/pairing.py", line 479, in _populate_accessories_and_characteristics
    accessories = await self._async_fetch_gatt_database()
  File "/usr/local/lib/python3.10/site-packages/aiohomekit/controller/ble/pairing.py", line 371, in _async_fetch_gatt_database
    decoded = CharacteristicTLV.decode(signature).to_dict()
  File "/usr/local/lib/python3.10/site-packages/aiohomekit/tlv8.py", line 284, in decode
    raise TlvParseException(f"Unknown TLV type {type} for {cls}")
aiohomekit.tlv8.TlvParseException: Unknown TLV type 11 for <class aiohomekit.controller.ble.structs.Characteristic>
```

Seen on a VOCOlinc VS1