### PR TITLE
Fix race in subscribing to chars

### DIFF
--- a/aiohomekit/controller/ble/pairing.py
+++ b/aiohomekit/controller/ble/pairing.py
@@ -281,6 +281,7 @@ class BlePairing(AbstractPairing):
                         listener(results)
 
         def _callback(id, data) -> None:
+            logger.debug("%s: Received event for iid=%s: %s", self.name, iid, data)
             if max_callback_enforcer.locked():
                 # Already one being read now, and one pending
                 return

--- a/aiohomekit/controller/ble/pairing.py
+++ b/aiohomekit/controller/ble/pairing.py
@@ -287,7 +287,11 @@ class BlePairing(AbstractPairing):
             async_create_task(_async_callback())
 
         logger.debug("%s: Subscribing to iid: %s", self.name, iid)
-        await self.client.start_notify(endpoint, _callback)
+        try:
+            await self.client.start_notify(endpoint, _callback)
+        except ValueError:
+            await self.client.stop_notify(endpoint)
+            await self.client.start_notify(endpoint, _callback)
         self._notifications.add(iid)
 
     async def _async_pair_verify(self):


### PR DESCRIPTION
Fixes
```
2022-07-16 15:56:48.625 ERROR (MainThread) [aiohomekit.utils] Failure running background task: Task-23737
Traceback (most recent call last):
  File "/Users/bdraco/home-assistant/venv/lib/python3.10/site-packages/aiohomekit/utils.py", line 28, in _handle_task_result
    task.result()
  File "/Users/bdraco/home-assistant/venv/lib/python3.10/site-packages/aiohomekit/controller/ble/pairing.py", line 503, in _async_start_notify_subscriptions
    await self._async_start_notify(iid)
  File "/Users/bdraco/home-assistant/venv/lib/python3.10/site-packages/aiohomekit/controller/ble/pairing.py", line 285, in _async_start_notify
    await self.client.start_notify(endpoint, _callback)
  File "/Users/bdraco/home-assistant/venv/lib/python3.10/site-packages/bleak/backends/corebluetooth/client.py", line 385, in start_notify
    await self._delegate.start_notifications(characteristic.obj, bleak_callback)
  File "/Users/bdraco/home-assistant/venv/lib/python3.10/site-packages/bleak/backends/corebluetooth/PeripheralDelegate.py", line 206, in start_notifications
    raise ValueError("Characteristic notifications already started")
ValueError: Characteristic notifications already started
```