### PR TITLE
Fix overly aggressive polling on dbus based systems

### DIFF
--- a/aiohomekit/controller/ble/pairing.py
+++ b/aiohomekit/controller/ble/pairing.py
@@ -278,6 +278,10 @@ class BlePairing(AbstractPairing):
 
         def _callback(id, data) -> None:
             logger.debug("%s: Received event for iid=%s: %s", self.name, iid, data)
+            if data != b"":
+                # We should only poll on empty messages, otherwise we may poll
+                # the device every second on DBUS systems.
+                return
             if max_callback_enforcer.locked():
                 # Already one being read now, and one pending
                 return


### PR DESCRIPTION
Dbus is noisy and gives us a lot more data than we want

```
2022-07-16 19:54:45.471 DEBUG (MainThread) [bleak.backends.bluezdbus.scanner] received D-Bus signal: org.freedesktop.DBus.Properties.PropertiesChanged (/org/bluez/hci0/dev_DC_39_FF_03_B5_97/service004d/char0056): ['org.bluez.GattCharacteristic1', {'Value': <dbus_next.signature.Variant ('ay', b'G\xbfP\x90Bq\x00<\x8d\xa0\xc9\xa2\x82\x85D\xbb\x8bp\x9e\xe9\x15\x95\xd8:')>}, []]
2022-07-16 19:54:45.473 DEBUG (MainThread) [bleak.backends.bluezdbus.scanner] received D-Bus signal: org.freedesktop.DBus.Properties.PropertiesChanged (/org/bluez/hci0/dev_DC_39_FF_03_B5_97/service004d/char0056): ['org.bluez.GattCharacteristic1', {'Value': <dbus_next.signature.Variant ('ay', b'G\xbfP\x90Bq\x00<\x8d\xa0\xc9\xa2\x82\x85D\xbb\x8bp\x9e\xe9\x15\x95\xd8:')>}, []]
```

Only if we get a callback with `b''` should we poll per the spec.

On Mac this is all we get