### PR TITLE
Use BLEDevice instead of address for bleak

### DIFF
--- a/aiohomekit/controller/ble/connection.py
+++ b/aiohomekit/controller/ble/connection.py
@@ -78,7 +78,7 @@ async def establish_connection(
             logger.debug("%s: Using existing BLE device with address %s", name, address)
         else:
             address = address_or_ble_device
-            logger.debug("%s: Resolving BLE device  with address %s", name, address)
+            logger.debug("%s: Resolving BLE device with address %s", name, address)
 
         if not client or client.address != address:
             # Only replace the client if the address has changed

--- a/aiohomekit/controller/ble/connection.py
+++ b/aiohomekit/controller/ble/connection.py
@@ -21,13 +21,13 @@ from collections.abc import Callable
 import logging
 
 import async_timeout
+from bleak.backends.device import BLEDevice
 
 from aiohomekit.exceptions import AccessoryDisconnectedError, AccessoryNotFoundError
 
 from .bleak import BLEAK_EXCEPTIONS, AIOHomeKitBleakClient
 
 logger = logging.getLogger(__name__)
-from bleak.backends.device import BLEDevice
 
 MAX_TRANSIENT_ERRORS = 9
 

--- a/aiohomekit/controller/ble/connection.py
+++ b/aiohomekit/controller/ble/connection.py
@@ -74,7 +74,9 @@ async def establish_connection(
         address_or_ble_device: str | BLEDevice = address_or_ble_device_callback()
         if isinstance(address_or_ble_device, BLEDevice):
             address = address_or_ble_device.address
+            logger.debug("%s: Using existing BLE device with address %s", name, address)
         else:
+            logger.debug("%s: Resolving BLE device  with address %s", name, address)
             address = address_or_ble_device
         if not client or client.address != address:
             # Only replace the client if the address has changed

--- a/aiohomekit/controller/ble/connection.py
+++ b/aiohomekit/controller/ble/connection.py
@@ -71,6 +71,7 @@ async def establish_connection(
 
     while True:
         attempt += 1
+
         address_or_ble_device: str | BLEDevice = address_or_ble_device_callback()
         if isinstance(address_or_ble_device, BLEDevice):
             address = address_or_ble_device.address
@@ -78,12 +79,13 @@ async def establish_connection(
         else:
             address = address_or_ble_device
             logger.debug("%s: Resolving BLE device  with address %s", name, address)
+
         if not client or client.address != address:
             # Only replace the client if the address has changed
             logger.debug(
                 "%s: Creating new client because address changed from %s to %s",
                 name,
-                client.address,
+                client.address if client else None,
                 address,
             )
             client = AIOHomeKitBleakClient(address)

--- a/aiohomekit/controller/ble/connection.py
+++ b/aiohomekit/controller/ble/connection.py
@@ -40,7 +40,6 @@ MAX_TRANSIENT_ERRORS = 9
 MAX_CONNECT_ATTEMPTS = 5
 BLEAK_TIMEOUT = 6.75
 OVERALL_TIMEOUT = 7
-DISCOVER_TIMEOUT = 30
 
 TRANSIENT_ERRORS = {"le-connection-abort-by-local", "br-connection-canceled"}
 

--- a/aiohomekit/controller/ble/connection.py
+++ b/aiohomekit/controller/ble/connection.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Callable
 import logging
-from typing import TYPE_CHECKING
 
 import async_timeout
 from bleak.backends.device import BLEDevice

--- a/aiohomekit/controller/ble/connection.py
+++ b/aiohomekit/controller/ble/connection.py
@@ -76,8 +76,8 @@ async def establish_connection(
             address = address_or_ble_device.address
             logger.debug("%s: Using existing BLE device with address %s", name, address)
         else:
-            logger.debug("%s: Resolving BLE device  with address %s", name, address)
             address = address_or_ble_device
+            logger.debug("%s: Resolving BLE device  with address %s", name, address)
         if not client or client.address != address:
             # Only replace the client if the address has changed
             logger.debug(

--- a/aiohomekit/controller/ble/connection.py
+++ b/aiohomekit/controller/ble/connection.py
@@ -63,7 +63,7 @@ async def establish_connection(
         logger.debug(
             "%s: Creating new client because address changed from %s to %s",
             name,
-            client.address,
+            client.address if client else None,
             device.address,
         )
         client = AIOHomeKitBleakClient(device)

--- a/aiohomekit/controller/ble/controller.py
+++ b/aiohomekit/controller/ble/controller.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
+import asyncio
 import logging
 from typing import AsyncIterable
-import asyncio
+
 from bleak import BleakScanner
 from bleak.backends.device import BLEDevice
 from bleak.backends.scanner import AdvertisementData

--- a/aiohomekit/controller/ble/controller.py
+++ b/aiohomekit/controller/ble/controller.py
@@ -5,12 +5,13 @@ from typing import Any, AsyncIterable
 
 from bleak import BleakScanner
 from bleak.exc import BleakDBusError, BleakError
-
+from bleak.backends.scanner import AdvertisementData
 from aiohomekit.characteristic_cache import CharacteristicCacheType
 from aiohomekit.controller.abstract import AbstractController
 from aiohomekit.controller.ble.manufacturer_data import HomeKitAdvertisement
 from aiohomekit.controller.ble.pairing import BlePairing
 from aiohomekit.exceptions import AccessoryNotFoundError
+from bleak.backends.device import BLEDevice
 
 from .discovery import BleDiscovery
 
@@ -27,7 +28,9 @@ class BleController(AbstractController):
     def __init__(self, char_cache: CharacteristicCacheType):
         super().__init__(char_cache=char_cache)
 
-    def _device_detected(self, device, advertisement_data):
+    def _device_detected(
+        self, device: BLEDevice, advertisement_data: AdvertisementData
+    ) -> None:
         try:
             data = HomeKitAdvertisement.from_advertisement(device, advertisement_data)
         except ValueError:

--- a/aiohomekit/controller/ble/controller.py
+++ b/aiohomekit/controller/ble/controller.py
@@ -87,6 +87,11 @@ class BleController(AbstractController):
         if discovery := self.discoveries.get(address):
             return discovery.device
 
+        logger.debug(
+            "BLE device %s not found, waiting for advertisement with timeout: %s",
+            address,
+            timeout,
+        )
         future = asyncio.Future()
         self._ble_futures.setdefault(address, []).append(future)
         try:

--- a/aiohomekit/controller/ble/controller.py
+++ b/aiohomekit/controller/ble/controller.py
@@ -39,6 +39,7 @@ class BleController(AbstractController):
 
         if pairing := self.pairings.get(data.id):
             pairing._async_description_update(data)
+            pairing._async_ble_device_update(device)
 
         if data.id in self.discoveries:
             self.discoveries[data.id]._async_process_advertisement(data)

--- a/aiohomekit/controller/ble/controller.py
+++ b/aiohomekit/controller/ble/controller.py
@@ -43,9 +43,7 @@ class BleController(AbstractController):
             pairing._async_ble_device_update(device)
 
         if futures := self._ble_futures.get(data.address):
-            logger.debug(
-                "BLE device for %s found, filling futures: %s", data.address, futures
-            )
+            logger.debug("BLE device for %s found, fulfilling futures", data.address)
             for future in futures:
                 future.set_result(device)
             futures.clear()
@@ -101,6 +99,11 @@ class BleController(AbstractController):
         try:
             return await asyncio.wait_for(future, timeout=timeout)
         except asyncio.TimeoutError:
+            logger.debug(
+                "Timed out after %s waiting for discovery of BLE device with address %s",
+                timeout,
+                address,
+            )
             return None
         finally:
             if address not in self._ble_futures:

--- a/aiohomekit/controller/ble/controller.py
+++ b/aiohomekit/controller/ble/controller.py
@@ -4,14 +4,15 @@ import logging
 from typing import Any, AsyncIterable
 
 from bleak import BleakScanner
-from bleak.exc import BleakDBusError, BleakError
+from bleak.backends.device import BLEDevice
 from bleak.backends.scanner import AdvertisementData
+from bleak.exc import BleakDBusError, BleakError
+
 from aiohomekit.characteristic_cache import CharacteristicCacheType
 from aiohomekit.controller.abstract import AbstractController
 from aiohomekit.controller.ble.manufacturer_data import HomeKitAdvertisement
 from aiohomekit.controller.ble.pairing import BlePairing
 from aiohomekit.exceptions import AccessoryNotFoundError
-from bleak.backends.device import BLEDevice
 
 from .discovery import BleDiscovery
 

--- a/aiohomekit/controller/ble/controller.py
+++ b/aiohomekit/controller/ble/controller.py
@@ -80,7 +80,9 @@ class BleController(AbstractController):
         for device in self.discoveries.values():
             yield device
 
-    async def async_get_ble_device(self, address: str, timeout: int) -> BLEDevice:
+    async def async_get_ble_device(
+        self, address: str, timeout: int
+    ) -> BLEDevice | None:
         """Get a BLE device by address."""
         if discovery := self.discoveries.get(address):
             return discovery.device

--- a/aiohomekit/controller/ble/controller.py
+++ b/aiohomekit/controller/ble/controller.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, AsyncIterable
+from typing import AsyncIterable
 
 from bleak import BleakScanner
 from bleak.backends.device import BLEDevice

--- a/aiohomekit/controller/ble/discovery.py
+++ b/aiohomekit/controller/ble/discovery.py
@@ -21,7 +21,6 @@ import logging
 from typing import TYPE_CHECKING
 import uuid
 
-from bleak.backends.device import BLEDevice
 from bleak.exc import BleakError
 
 from aiohomekit.controller.abstract import AbstractDiscovery, FinishPairing
@@ -42,6 +41,7 @@ from .client import (
 from .connection import establish_connection
 from .manufacturer_data import HomeKitAdvertisement
 from .pairing import BlePairing
+from bleak.backends.device import BLEDevice
 
 if TYPE_CHECKING:
     from aiohomekit.controller.ble.controller import BleController
@@ -67,7 +67,6 @@ class BleDiscovery(AbstractDiscovery):
         self.description = description
         self.controller = controller
         self.device = device
-
         self.client: AIOHomeKitBleakClient | None = None
         self._connection_lock = asyncio.Lock()
 
@@ -152,7 +151,10 @@ class BleDiscovery(AbstractDiscovery):
             pairing["Connection"] = "BLE"
 
             obj = self.controller.pairings[alias] = BlePairing(
-                self.controller, pairing, self.client, self.description
+                self.controller,
+                pairing,
+                client=self.client,
+                description=self.description,
             )
             return obj
 

--- a/aiohomekit/controller/ble/discovery.py
+++ b/aiohomekit/controller/ble/discovery.py
@@ -70,12 +70,6 @@ class BleDiscovery(AbstractDiscovery):
         self.client: AIOHomeKitBleakClient | None = None
         self._connection_lock = asyncio.Lock()
 
-    def get_address_or_ble_device(self) -> str | BLEDevice:
-        """Return the most current address for the device."""
-        if self.description.address == self.device.address:
-            return self.device
-        return self.description.address
-
     @property
     def name(self):
         return f"{self.description.name} ({self.description.address})"

--- a/aiohomekit/controller/ble/discovery.py
+++ b/aiohomekit/controller/ble/discovery.py
@@ -90,8 +90,8 @@ class BleDiscovery(AbstractDiscovery):
                 return
             self.client = await establish_connection(
                 self.client,
+                self.device,
                 self.name,
-                self.get_address_or_ble_device,
                 self._async_disconnected,
             )
 

--- a/aiohomekit/controller/ble/discovery.py
+++ b/aiohomekit/controller/ble/discovery.py
@@ -21,6 +21,7 @@ import logging
 from typing import TYPE_CHECKING
 import uuid
 
+from bleak.backends.device import BLEDevice
 from bleak.exc import BleakError
 
 from aiohomekit.controller.abstract import AbstractDiscovery, FinishPairing
@@ -41,7 +42,6 @@ from .client import (
 from .connection import establish_connection
 from .manufacturer_data import HomeKitAdvertisement
 from .pairing import BlePairing
-from bleak.backends.device import BLEDevice
 
 if TYPE_CHECKING:
     from aiohomekit.controller.ble.controller import BleController

--- a/aiohomekit/controller/ble/pairing.py
+++ b/aiohomekit/controller/ble/pairing.py
@@ -197,7 +197,7 @@ class BlePairing(AbstractPairing):
 
     def _async_ble_device_update(self, device: BLEDevice) -> None:
         """Update the BLE device."""
-        if device.address != self.device.address:
+        if self.device and device.address != self.device.address:
             logger.debug(
                 "BLE address changed from %s to %s; closing connection",
                 self.device.address,

--- a/aiohomekit/controller/ble/pairing.py
+++ b/aiohomekit/controller/ble/pairing.py
@@ -388,6 +388,7 @@ class BlePairing(AbstractPairing):
             logger.warning(
                 "%s: Failed to fetch disconnected events: %s", self.name, exc
             )
+            return
 
         for listener in self.listeners:
             listener(results)

--- a/aiohomekit/controller/ble/pairing.py
+++ b/aiohomekit/controller/ble/pairing.py
@@ -151,7 +151,7 @@ class BlePairing(AbstractPairing):
 
     def get_address_or_ble_device(self) -> str | BLEDevice:
         """Return the most current address for the device."""
-        if self.address == self.device.address:
+        if self.device and self.address == self.device.address:
             return self.device
         return self.address
 
@@ -194,6 +194,10 @@ class BlePairing(AbstractPairing):
     def transport(self) -> Transport:
         """The transport used for the connection."""
         return Transport.BLE
+
+    def _async_device_update(self, device: BLEDevice) -> None:
+        """Update the BLE device."""
+        self.device = device
 
     def _async_description_update(self, description: HomeKitAdvertisement | None):
         """Update the description of the accessory."""

--- a/aiohomekit/controller/ble/pairing.py
+++ b/aiohomekit/controller/ble/pairing.py
@@ -580,15 +580,16 @@ class BlePairing(AbstractPairing):
             # The iid will not be in in self._notifications until
             # the _async_start_notify call returns.
             async with self._subscription_lock:
-                if iid not in self._notifications and self.client.is_connected:
-                    try:
-                        await self._async_start_notify(iid)
-                    except BLEAK_EXCEPTIONS as ex:
-                        # Likely disconnected before we could start notifications
-                        # we will get disconnected events instead.
-                        logger.debug(
-                            "%s: Could not start notify for %s: %s", self.name, iid, ex
-                        )
+                if iid in self._notifications or not self.client.is_connected:
+                    continue
+                try:
+                    await self._async_start_notify(iid)
+                except BLEAK_EXCEPTIONS as ex:
+                    # Likely disconnected before we could start notifications
+                    # we will get disconnected events instead.
+                    logger.debug(
+                        "%s: Could not start notify for %s: %s", self.name, iid, ex
+                    )
 
     @operation_lock
     @retry_bluetooth_connection_error()

--- a/aiohomekit/controller/ble/pairing.py
+++ b/aiohomekit/controller/ble/pairing.py
@@ -156,7 +156,7 @@ class BlePairing(AbstractPairing):
         return self.address
 
     @property
-    def address(self):
+    def address(self) -> str:
         return (
             self.description.address
             if self.description
@@ -195,7 +195,7 @@ class BlePairing(AbstractPairing):
         """The transport used for the connection."""
         return Transport.BLE
 
-    def _async_device_update(self, device: BLEDevice) -> None:
+    def _async_ble_device_update(self, device: BLEDevice) -> None:
         """Update the BLE device."""
         self.device = device
 

--- a/aiohomekit/controller/ble/pairing.py
+++ b/aiohomekit/controller/ble/pairing.py
@@ -26,8 +26,8 @@ import time
 from typing import TYPE_CHECKING, Any, TypeVar, cast
 import uuid
 
-from bleak.exc import BleakError
 from bleak.backends.device import BLEDevice
+from bleak.exc import BleakError
 
 from aiohomekit.exceptions import (
     AccessoryDisconnectedError,

--- a/aiohomekit/controller/ble/pairing.py
+++ b/aiohomekit/controller/ble/pairing.py
@@ -99,6 +99,9 @@ class BlePairing(AbstractPairing):
     This represents a paired HomeKit IP accessory.
     """
 
+    description: HomeKitAdvertisement
+    controller: BleController
+
     def __init__(
         self,
         controller: BleController,

--- a/aiohomekit/controller/ble/pairing.py
+++ b/aiohomekit/controller/ble/pairing.py
@@ -581,7 +581,14 @@ class BlePairing(AbstractPairing):
             # the _async_start_notify call returns.
             async with self._subscription_lock:
                 if iid not in self._notifications and self.client.is_connected:
-                    await self._async_start_notify(iid)
+                    try:
+                        await self._async_start_notify(iid)
+                    except BLEAK_EXCEPTIONS as ex:
+                        # Likely disconnected before we could start notifications
+                        # we will get disconnected events instead.
+                        logger.debug(
+                            "%s: Could not start notify for %s: %s", self.name, iid, ex
+                        )
 
     @operation_lock
     @retry_bluetooth_connection_error()


### PR DESCRIPTION
- If we pass a BLEDevice bleak does not need to make a new
  scanner under the hood