### PR TITLE
Small fixes for BLE devices

### DIFF
--- a/aiohomekit/controller/ble/structs.py
+++ b/aiohomekit/controller/ble/structs.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from __future__ import annotations
 
 from dataclasses import dataclass, field
 import enum

--- a/aiohomekit/controller/ble/structs.py
+++ b/aiohomekit/controller/ble/structs.py
@@ -17,6 +17,7 @@
 from dataclasses import dataclass, field
 import enum
 import struct
+from typing import Any
 
 from aiohomekit.tlv8 import TLVStruct, tlv_entry, u8, u16, u128
 
@@ -186,57 +187,85 @@ class Characteristic(TLVStruct):
 
     @property
     def value(self):
+        return self._unpack_value(self._value)
+
+    def _unpack_value(self, value: bytes) -> Any:
         if not self.pf_format:
-            return self._value
-        elif self.pf_format == 0x01:
-            val = struct.unpack("<B", self._value)[0]
+            return value
+        if self.pf_format == 0x01:
+            val = struct.unpack("<B", value)[0]
             return bool(val)
-        elif self.pf_format == 0x04:
-            return struct.unpack("<B", self._value)[0]
-        elif self.pf_format == 0x06:
-            return struct.unpack("<H", self._value)[0]
-        elif self.pf_format == 0x08:
-            return struct.unpack("<L", self._value)[0]
-        elif self.pf_format == 0x0A:
-            return struct.unpack("<Q", self._value)[0]
-        elif self.pf_format == 0x10:
-            return struct.unpack("<l", self._value)[0]
-        elif self.pf_format == 0x14:
-            return struct.unpack("<f", self._value)[0]
-        elif self.pf_format == 0x19:
-            return bytes.decode(self._value)
-        elif self.pf_format == 0x1B:
+        if self.pf_format == 0x04:
+            return struct.unpack("<B", value)[0]
+        if self.pf_format == 0x06:
+            return struct.unpack("<H", value)[0]
+        if self.pf_format == 0x08:
+            return struct.unpack("<L", value)[0]
+        if self.pf_format == 0x0A:
+            return struct.unpack("<Q", value)[0]
+        if self.pf_format == 0x10:
+            return struct.unpack("<l", value)[0]
+        if self.pf_format == 0x14:
+            return struct.unpack("<f", value)[0]
+        if self.pf_format == 0x19:
+            return bytes.decode(value)
+        if self.pf_format == 0x1B:
             # ???
-            return self._value.hex()
-        else:
-            return self._value
+            return value.hex()
+        return value
 
     @value.setter
     def value(self, value):
+        self._value = self._pack_value(value)
+
+    def _pack_value(self, value: Any) -> bytes:
         # if data type is unknown, copy value without modification
         if not self.pf_format:
-            self._value = value
-        elif self.pf_format == 0x01:
-            self._value = b"\x01" if value else b"\x00"
-        elif self.pf_format == 0x04:
-            self._value = struct.pack("<B", value)
-        elif self.pf_format == 0x06:
-            self._value = struct.pack("<H", value)
-        elif self.pf_format == 0x08:
-            self._value = struct.pack("<L", value)
-        elif self.pf_format == 0x0A:
-            self._value = struct.pack("<Q", value)
-        elif self.pf_format == 0x10:
-            self._value = struct.pack("<l", value)
-        elif self.pf_format == 0x14:
-            self._value = struct.pack("<f", value)
-        elif self.pf_format == 0x19:
-            self._value = value.encode()
-        elif self.pf_format == 0x1B:
+            return value
+        if self.pf_format == 0x01:
+            return b"\x01" if value else b"\x00"
+        if self.pf_format == 0x04:
+            return struct.pack("<B", value)
+        if self.pf_format == 0x06:
+            return struct.pack("<H", value)
+        if self.pf_format == 0x08:
+            return struct.pack("<L", value)
+        if self.pf_format == 0x0A:
+            return struct.pack("<Q", value)
+        if self.pf_format == 0x10:
+            return struct.pack("<l", value)
+        if self.pf_format == 0x14:
+            return struct.pack("<f", value)
+        if self.pf_format == 0x19:
+            return value.encode()
+        if self.pf_format == 0x1B:
             # ???
-            self._value = bytes.fromhex(value)
-        else:
-            self._value = value
+            return bytes.fromhex(value)
+        return value
+
+    @property
+    def min_step(self) -> Any:
+        if not self.step_value:
+            return None
+        return self._unpack_value(self.step_value)
+
+    @property
+    def min_max_value(self) -> tuple[int | float, int | float] | None:
+        if not self.valid_range:
+            return None
+        if self.pf_format == 0x04:
+            return struct.unpack("<BB", self.valid_range)
+        if self.pf_format == 0x06:
+            return struct.unpack("<HH", self.valid_range)
+        if self.pf_format == 0x08:
+            return struct.unpack("<LL", self.valid_range)
+        if self.pf_format == 0x0A:
+            return struct.unpack("<QQ", self.valid_range)
+        if self.pf_format == 0x10:
+            return struct.unpack("<ll", self.valid_range)
+        if self.pf_format == 0x14:
+            return struct.unpack("<ff", self.valid_range)
+        return None
 
     def to_dict(self):
         perms = list()
@@ -267,5 +296,13 @@ class Characteristic(TLVStruct):
 
         if self._value is not None:
             result["value"] = self.value
+
+        if self.min_step:
+            result["minStep"] = self.min_step
+
+        if self.min_max_value:
+            min_max_value = self.min_max_value
+            result["minValue"] = min_max_value[0]
+            result["maxValue"] = min_max_value[1]
 
         return result


### PR DESCRIPTION
- Remove notify workaround since we are now using
  a new BleakClient object every time and the problem
  goes away

- Fix missing minStep/minValue/maxValue resulting in
  unexpected errors when changing color temp (etc)

Fixes
```
2022-07-25 17:01:26.391 ERROR (MainThread) [homeassistant.components.websocket_api.http.connection] [4449491824] Nanoleaf Light Bulb (C8F2A86D-F301-67C3-48AE-EC9280F5A18C): PDU status was not success: Invalid request (6)
Traceback (most recent call last):
  File "/Users/bdraco/home-assistant/homeassistant/components/websocket_api/commands.py", line 199, in handle_call_service
    await hass.services.async_call(
  File "/Users/bdraco/home-assistant/homeassistant/core.py", line 1713, in async_call
    task.result()
  File "/Users/bdraco/home-assistant/homeassistant/core.py", line 1750, in _execute_service
    await cast(Callable[[ServiceCall], Awaitable[None]], handler.job.target)(
  File "/Users/bdraco/home-assistant/homeassistant/helpers/entity_component.py", line 204, in handle_service
    await service.entity_service_call(
  File "/Users/bdraco/home-assistant/homeassistant/helpers/service.py", line 676, in entity_service_call
    future.result()  # pop exception if have
  File "/Users/bdraco/home-assistant/homeassistant/helpers/entity.py", line 930, in async_request_call
    await coro
  File "/Users/bdraco/home-assistant/homeassistant/helpers/service.py", line 713, in _handle_entity_call
    await result
  File "/Users/bdraco/home-assistant/homeassistant/components/light/__init__.py", line 553, in async_handle_light_on_service
    await light.async_turn_on(**filter_turn_on_params(light, params))
  File "/Users/bdraco/home-assistant/homeassistant/components/homekit_controller/light.py", line 144, in async_turn_on
    await self.async_put_characteristics(characteristics)
  File "/Users/bdraco/home-assistant/homeassistant/components/homekit_controller/__init__.py", line 109, in async_put_characteristics
    return await self._accessory.put_characteristics(payload)
  File "/Users/bdraco/home-assistant/homeassistant/components/homekit_controller/connection.py", line 633, in put_characteristics
    results = await self.pairing.put_characteristics(characteristics)
  File "/Users/bdraco/home-assistant/venv/lib/python3.10/site-packages/aiohomekit/controller/ble/pairing.py", line 102, in _async_wrap
    return await func(self, *args, **kwargs)
  File "/Users/bdraco/home-assistant/venv/lib/python3.10/site-packages/aiohomekit/controller/ble/client.py", line 63, in _async_wrap
    return await func(*args, **kwargs)
  File "/Users/bdraco/home-assistant/venv/lib/python3.10/site-packages/aiohomekit/controller/ble/pairing.py", line 745, in put_characteristics
    await self._async_request(OpCode.CHAR_WRITE, iid, payload)
  File "/Users/bdraco/home-assistant/venv/lib/python3.10/site-packages/aiohomekit/controller/ble/pairing.py", line 282, in _async_request
    raise ValueError(
ValueError: Nanoleaf Light Bulb (C8F2A86D-F301-67C3-48AE-EC9280F5A18C): PDU status was not success: Invalid request (6)```