### PR TITLE
Use legacy typing to resolve tlv exception

### DIFF
--- a/aiohomekit/controller/ble/structs.py
+++ b/aiohomekit/controller/ble/structs.py
@@ -13,11 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from ctypes import Union
 from dataclasses import dataclass, field
 import enum
 import struct
-from typing import Any, Optional, Tuple
+from typing import Any, Optional, Tuple, Union
 
 from aiohomekit.tlv8 import TLVStruct, tlv_entry, u8, u16, u128
 

--- a/aiohomekit/controller/ble/structs.py
+++ b/aiohomekit/controller/ble/structs.py
@@ -13,12 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from __future__ import annotations
-
+from ctypes import Union
 from dataclasses import dataclass, field
 import enum
 import struct
-from typing import Any
+from typing import Any, Optional, Tuple
 
 from aiohomekit.tlv8 import TLVStruct, tlv_entry, u8, u16, u128
 
@@ -251,7 +250,7 @@ class Characteristic(TLVStruct):
         return self._unpack_value(self.step_value)
 
     @property
-    def min_max_value(self) -> tuple[int | float, int | float] | None:
+    def min_max_value(self) -> Optional[Tuple[Union[int, float], Union[int, float]]]:
         if not self.valid_range:
             return None
         if self.pf_format == 0x04:


### PR DESCRIPTION
With `from __future__ import annotations` seeing the below.

The deserialize function has some magic with `__mro__` that doesn't seem to play nice.

Revert to using legacy typing for now until we can figure out what the root cause is.
> 
> ```
> 2022-07-26 02:21:14.700 ERROR (MainThread) [homeassistant.components.homekit_controller.config_flow] Pairing attempt failed with an unhandled exception
> Traceback (most recent call last):
>   File "/usr/src/homeassistant/homeassistant/components/homekit_controller/config_flow.py", line 481, in async_step_pair
>     self.finish_pairing = await discovery.async_start_pairing(self.hkid)
>   File "/usr/local/lib/python3.10/site-packages/aiohomekit/controller/ble/client.py", line 63, in _async_wrap
>     return await func(*args, **kwargs)
>   File "/usr/local/lib/python3.10/site-packages/aiohomekit/controller/ble/discovery.py", line 121, in async_start_pairing
>     salt, pub_key = await drive_pairing_state_machine(
>   File "/usr/local/lib/python3.10/site-packages/aiohomekit/controller/ble/client.py", line 205, in drive_pairing_state_machine
>     response = await char_write(
>   File "/usr/local/lib/python3.10/site-packages/aiohomekit/controller/ble/client.py", line 163, in char_write
>     body = BleRequest(expect_response=1, value=body).encode()
>   File "/usr/local/lib/python3.10/site-packages/aiohomekit/tlv8.py", line 260, in encode
>     serializer = find_serializer(py_type)
>   File "/usr/local/lib/python3.10/site-packages/aiohomekit/tlv8.py", line 222, in find_serializer
>     raise TlvSerializeException(f"Cannot serialize {py_type} to TLV8")
> aiohomekit.tlv8.TlvSerializeException: Cannot serialize u8 to TLV8
> ```

