### PR TITLE
Fix pairing with devices that use a config number of 0

### DIFF
--- a/aiohomekit/controller/abstract.py
+++ b/aiohomekit/controller/abstract.py
@@ -86,7 +86,7 @@ class AbstractPairing(metaclass=ABCMeta):
     def config_num(self) -> int:
         """Wrapper around the accessories state to make it easier to use."""
         if not self._accessories_state:
-            return 0
+            return -1
         return self._accessories_state.config_num
 
     @property

--- a/aiohomekit/controller/ble/pairing.py
+++ b/aiohomekit/controller/ble/pairing.py
@@ -422,6 +422,7 @@ class BlePairing(AbstractPairing):
             listener(results)
 
     async def _async_fetch_gatt_database(self) -> Accessories:
+        logger.debug("%s: Fetching GATT database", self.name)
         accessory = Accessory()
         accessory.aid = 1
         for service in self.client.services:
@@ -475,6 +476,7 @@ class BlePairing(AbstractPairing):
 
         accessories = Accessories()
         accessories.add_accessory(accessory)
+        logger.debug("%s: Completed fetching GATT database", self.name)
 
         return accessories
 

--- a/aiohomekit/model/__init__.py
+++ b/aiohomekit/model/__init__.py
@@ -40,6 +40,8 @@ __all__ = [
     "CharacteristicFormats",
     "FeatureFlags",
     "Accessory",
+    "Service",
+    "ServiceTypes",
     "Transport",
 ]
 

--- a/aiohomekit/model/characteristics/characteristic.py
+++ b/aiohomekit/model/characteristics/characteristic.py
@@ -32,7 +32,7 @@ from .data import characteristics
 from .permissions import CharacteristicPermissions
 
 if TYPE_CHECKING:
-    from aiohomekit.model.service import Service
+    from aiohomekit.model import Service
 
 
 DEFAULT_FOR_TYPE = {


### PR DESCRIPTION
Since the device presented a config number of 0 we never fetched the values because we believed we were already up to date since the default was 0

Fixes #128