### PR TITLE
Add typing hints to accessories.serialize()

### DIFF
--- a/aiohomekit/model/__init__.py
+++ b/aiohomekit/model/__init__.py
@@ -23,6 +23,7 @@ import aiohomekit.hkjson as hkjson
 from aiohomekit.protocol.statuscodes import to_status_code
 from aiohomekit.uuid import normalize_uuid
 
+from . import entity_map
 from .categories import Categories
 from .characteristics import (
     Characteristic,
@@ -33,7 +34,6 @@ from .characteristics import (
 from .feature_flags import FeatureFlags
 from .mixin import get_id
 from .services import Service, ServicesTypes
-from . import entity_map
 
 __all__ = [
     "Categories",

--- a/aiohomekit/model/__init__.py
+++ b/aiohomekit/model/__init__.py
@@ -33,6 +33,7 @@ from .characteristics import (
 from .feature_flags import FeatureFlags
 from .mixin import get_id
 from .services import Service, ServicesTypes
+from . import entity_map
 
 __all__ = [
     "Categories",
@@ -303,7 +304,7 @@ class Accessories:
             return cls.from_list(hkjson.loads(fp.read()))
 
     @classmethod
-    def from_list(cls, accessories: list[dict[str, Any]]) -> Accessories:
+    def from_list(cls, accessories: entity_map.Accesories) -> Accessories:
         self = cls()
         for accessory in accessories:
             self.add_accessory(Accessory.create_from_dict(accessory))
@@ -312,13 +313,13 @@ class Accessories:
     def add_accessory(self, accessory: Accessory) -> None:
         self.accessories.append(accessory)
 
-    def serialize(self):
+    def serialize(self) -> entity_map.Accesories:
         accessories_list = []
         for a in self.accessories:
             accessories_list.append(a.to_accessory_and_service_list())
         return accessories_list
 
-    def to_accessory_and_service_list(self):
+    def to_accessory_and_service_list(self) -> dict[str, entity_map.Accesories]:
         d = {"accessories": self.serialize()}
         return hkjson.dumps(d)
 

--- a/aiohomekit/model/entity_map.py
+++ b/aiohomekit/model/entity_map.py
@@ -1,0 +1,57 @@
+#
+# Copyright 2022 aiohomekit team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Typing hints for the serialization format used by the JSON part of the HomeKit API.
+"""
+
+from __future__ import annotations
+
+from typing import TypedDict, Union
+
+Characteristic = TypedDict(
+    "Characteristic",
+    {
+        "type": str,
+        "iid": int,
+        "description": str,
+        "value": Union[str, float, int, bool],
+        "perms": list[str],
+        "unit": str,
+        "format": str,
+        "valid-values": list[int],
+        "minValue": Union[int, float],
+        "maxValue": Union[int, float],
+        "minStep": Union[int, float],
+        "minLen": int,
+    },
+    total=False,
+)
+
+
+class Service(TypedDict, total=False):
+    type: str
+    iid: int
+    characteristics: list[Characteristic]
+    linked: list[int]
+
+
+class Accessory(TypedDict, total=True):
+    aid: int
+    services: list[Service]
+
+
+Accesories = list[Accessory]


### PR DESCRIPTION
This is the fix for one of only 2 failures left when turning on strict mypy for hkc's config_flow module.