### PR TITLE
Fix typing of reconnect_soon

### DIFF
--- a/aiohomekit/controller/abstract.py
+++ b/aiohomekit/controller/abstract.py
@@ -228,7 +228,7 @@ class AbstractPairing(metaclass=ABCMeta):
     async def unsubscribe(self, characteristics: Iterable[tuple[int, int]]) -> None:
         self.subscriptions.difference_update(characteristics)
 
-    async def reconnect_soon(self):
+    async def reconnect_soon(self) -> None:
         """
         Notify the pairing that we have noticed a network change that means its connection maybe stale.
 

--- a/aiohomekit/controller/coap/pairing.py
+++ b/aiohomekit/controller/coap/pairing.py
@@ -219,3 +219,12 @@ class CoAPPairing(AbstractPairing):
     async def remove_pairing(self, pairingId):
         await self._ensure_connected()
         return await self.connection.remove_pairing(pairingId)
+
+    async def reconnect_soon(self) -> None:
+        # Conventiently Home Assistant mutates self.pairing_data for us
+        # So we can just re-read from pairing data.
+        # This is kinda gross but there is a longer term plan to refactor
+        # this API away, so will do for now
+        address = self.pairing_data["AccessoryAddress"]
+        port = self.pairing_data["AccessoryPort"]
+        await self.connection.reconnect_soon(f"{address}:{port}")

--- a/aiohomekit/controller/ip/connection.py
+++ b/aiohomekit/controller/ip/connection.py
@@ -236,7 +236,7 @@ class HomeKitConnection:
         self._connector = async_create_task(self._reconnect())
         self._connector.add_done_callback(done_callback)
 
-    async def reconnect_soon(self, updated_ip_port=None):
+    async def reconnect_soon(self) -> None:
         """Reconnect to the device if disconnected.
 
         If a reconnect is in progress, the reconnection wait is canceled

--- a/aiohomekit/controller/ip/pairing.py
+++ b/aiohomekit/controller/ip/pairing.py
@@ -510,5 +510,5 @@ class IpPairing(AbstractPairing):
 
         return resp.body
 
-    async def reconnect_soon(self):
+    async def reconnect_soon(self) -> None:
         return await self.connection.reconnect_soon()


### PR DESCRIPTION
This fixes reconnect_soon to have a return type. This I think means we can turn on the strictest mypy settings in home assistant for the config_flow module.

While i was there I tweaked reconnect_soon in CoAP so that connection object always get passed the latest ip/port (in case the accessory changed ip but we haven't noticed yet). This was the latest outstanding CoAP issue i knew about before the recent refactoring work. This is kinda of hacky, but what the IP backend is doing AFAICT. Ideally we'd have it pull the latest details out of the zeroconf cache directly itself rather that relying on the pairing_data changing under us.