### PR TITLE
Improve TLV decode debug logging

### DIFF
--- a/aiohomekit/controller/ble/discovery.py
+++ b/aiohomekit/controller/ble/discovery.py
@@ -113,11 +113,14 @@ class BleDiscovery(AbstractDiscovery):
         ff_iid = await self.client.get_characteristic_iid(ff_char)
         ff_raw = await char_read(self.client, None, None, ff_char.handle, ff_iid)
         ff = FeatureFlags(ff_raw[0])
+        with_auth = pair_with_auth(ff)
+        if with_auth:
+            logger.debug("%s: Pairing with auth since flags are: %s", self.name, ff)
         return await drive_pairing_state_machine(
             self.client,
             CharacteristicsTypes.PAIR_SETUP,
             perform_pair_setup_part1(
-                with_auth=pair_with_auth(ff),
+                with_auth=with_auth,
             ),
         )
 

--- a/aiohomekit/controller/ble/discovery.py
+++ b/aiohomekit/controller/ble/discovery.py
@@ -113,14 +113,11 @@ class BleDiscovery(AbstractDiscovery):
         ff_iid = await self.client.get_characteristic_iid(ff_char)
         ff_raw = await char_read(self.client, None, None, ff_char.handle, ff_iid)
         ff = FeatureFlags(ff_raw[0])
-        with_auth = pair_with_auth(ff)
-        if with_auth:
-            logger.debug("%s: Pairing with auth since flags are: %s", self.name, ff)
         return await drive_pairing_state_machine(
             self.client,
             CharacteristicsTypes.PAIR_SETUP,
             perform_pair_setup_part1(
-                with_auth=with_auth,
+                with_auth=pair_with_auth(ff),
             ),
         )
 

--- a/aiohomekit/protocol/__init__.py
+++ b/aiohomekit/protocol/__init__.py
@@ -107,7 +107,7 @@ def perform_pair_setup_part1(
     #
     # Step #1 ios --> accessory (send SRP start Request) (see page 39)
     #
-    logging.debug("#1 ios -> accessory: send SRP start request")
+    logger.debug("#1 ios -> accessory: send SRP start request")
     request_tlv = [
         (TLV.kTLVType_State, TLV.M1),
         (TLV.kTLVType_Method, TLV.PairSetupWithAuth if with_auth else TLV.PairSetup),
@@ -124,7 +124,7 @@ def perform_pair_setup_part1(
     #
     # Step #3 ios --> accessory (send SRP verify request) (see page 41)
     #
-    logging.debug("#3 ios -> accessory: send SRP verify request")
+    logger.debug("#3 ios -> accessory: send SRP verify request")
     response_tlv = dict(response_tlv)
     handle_state_step(response_tlv, TLV.M2)
 
@@ -215,7 +215,7 @@ def perform_pair_setup_part2(
     #
     # Step #5 ios --> accessory (Exchange Request) (see page 43)
     #
-    logging.debug("#5 ios -> accessory: send SRP exchange request")
+    logger.debug("#5 ios -> accessory: send SRP exchange request")
 
     # M4 Verification (page 43)
     response_tlv = dict(response_tlv)

--- a/aiohomekit/protocol/tlv.py
+++ b/aiohomekit/protocol/tlv.py
@@ -55,7 +55,7 @@ class HAP_TLV(enum.IntEnum):
 
 K_TLV_TYPE_NAMES = {
     0: "Method",
-    1: "Identifer",
+    1: "Identifier",
     2: "Salt",
     3: "PublicKey",
     4: "Proof",
@@ -222,7 +222,7 @@ class TLV:
     @staticmethod
     def to_string(d: Any) -> str:
         def entry_to_string(entry_key, entry_value) -> str:
-            tlv_key = k[0]
+            tlv_key = entry_key if isinstance(entry_key, int) else entry_key[0]
             name = K_TLV_TYPE_NAMES.get(tlv_key, UNKNOWN_TLV_TYPE_NAME)
             value_description = ""
             if tlv_key == TLV.kTLVType_Error:
@@ -230,9 +230,9 @@ class TLV:
                     entry_value[0], UNKNOWN_TLV_ERROR_NAME
                 )
             if value_description:
-                value_description = f"[{value_description}]"
+                value_description = f" [{value_description}]"
             if isinstance(entry_value, bytearray):
-                return "  {k} ({key_name}): ({len} bytes/{t}) 0x{v} {value_description}\n".format(
+                return "  {k} ({key_name}): ({len} bytes/{t}) 0x{v}{value_description}\n".format(
                     k=entry_key,
                     key_name=name,
                     v=entry_value.hex(),
@@ -240,7 +240,7 @@ class TLV:
                     t=type(entry_value),
                     value_description=value_description,
                 )
-            return "  {k} ({key_name}): ({len} bytes/{t}) {v} {value_description}\n".format(
+            return "  {k} ({key_name}): ({len} bytes/{t}) {v}{value_description}\n".format(
                 k=entry_key,
                 key_name=name,
                 v=entry_value,

--- a/aiohomekit/protocol/tlv.py
+++ b/aiohomekit/protocol/tlv.py
@@ -240,13 +240,15 @@ class TLV:
                     t=type(entry_value),
                     value_description=value_description,
                 )
-            return "  {k} ({key_name}): ({len} bytes/{t}) {v}{value_description}\n".format(
-                k=entry_key,
-                key_name=name,
-                v=entry_value,
-                len=len(entry_value),
-                t=type(entry_value),
-                value_description=value_description,
+            return (
+                "  {k} ({key_name}): ({len} bytes/{t}) {v}{value_description}\n".format(
+                    k=entry_key,
+                    key_name=name,
+                    v=entry_value,
+                    len=len(entry_value),
+                    t=type(entry_value),
+                    value_description=value_description,
+                )
             )
 
         if isinstance(d, dict):

--- a/aiohomekit/protocol/tlv.py
+++ b/aiohomekit/protocol/tlv.py
@@ -53,6 +53,28 @@ class HAP_TLV(enum.IntEnum):
     kTLVHAPParamUnknown_1A_AccessoryInstanceId = 0x1A
 
 
+K_TLV_TYPE_NAMES = {
+    0: "Method",
+    1: "Identifer",
+    2: "Salt",
+    3: "PublicKey",
+    4: "Proof",
+    5: "EncryptedData",
+    6: "State",
+    7: "Error",
+    8: "RetryDelay",
+    9: "Certificate",
+    10: "Signature",
+    11: "Permissions",
+    12: "FragmentData",
+    13: "FragmentLast",
+    14: "SessionID",
+    255: "Separator",
+}
+
+UNKNOWN_TLV_TYPE_NAME = "Unknown"
+
+
 class TLV:
     """
     as described in Appendix 12 (page 251)
@@ -187,15 +209,21 @@ class TLV:
     @staticmethod
     def to_string(d: Any) -> str:
         def entry_to_string(entry_key, entry_value) -> str:
+            name = K_TLV_TYPE_NAMES.get(k[0], UNKNOWN_TLV_TYPE_NAME)
             if isinstance(entry_value, bytearray):
-                return "  {k}: ({len} bytes/{t}) 0x{v}\n".format(
+                return "  {k} ({key_name}): ({len} bytes/{t}) 0x{v}\n".format(
                     k=entry_key,
+                    key_name=name,
                     v=entry_value.hex(),
                     len=len(entry_value),
                     t=type(entry_value),
                 )
-            return "  {k}: ({len} bytes/{t}) {v}\n".format(
-                k=entry_key, v=entry_value, len=len(entry_value), t=type(entry_value)
+            return "  {k} ({key_name}): ({len} bytes/{t}) {v}\n".format(
+                k=entry_key,
+                key_name=name,
+                v=entry_value,
+                len=len(entry_value),
+                t=type(entry_value),
             )
 
         if isinstance(d, dict):

--- a/aiohomekit/protocol/tlv.py
+++ b/aiohomekit/protocol/tlv.py
@@ -75,6 +75,19 @@ K_TLV_TYPE_NAMES = {
 UNKNOWN_TLV_TYPE_NAME = "Unknown"
 
 
+K_TLV_ERROR_NAMES = {
+    1: "Unknown",
+    2: "Authentication",
+    3: "Backoff",
+    4: "MaxPeers",
+    5: "MaxTries",
+    6: "Unavailable",
+    7: "Busy",
+}
+
+UNKNOWN_TLV_ERROR_NAME = "Unknown"
+
+
 class TLV:
     """
     as described in Appendix 12 (page 251)
@@ -209,21 +222,31 @@ class TLV:
     @staticmethod
     def to_string(d: Any) -> str:
         def entry_to_string(entry_key, entry_value) -> str:
-            name = K_TLV_TYPE_NAMES.get(k[0], UNKNOWN_TLV_TYPE_NAME)
+            tlv_key = k[0]
+            name = K_TLV_TYPE_NAMES.get(tlv_key, UNKNOWN_TLV_TYPE_NAME)
+            value_description = ""
+            if tlv_key == TLV.kTLVType_Error:
+                value_description = K_TLV_ERROR_NAMES.get(
+                    entry_value[0], UNKNOWN_TLV_ERROR_NAME
+                )
+            if value_description:
+                value_description = f"[{value_description}]"
             if isinstance(entry_value, bytearray):
-                return "  {k} ({key_name}): ({len} bytes/{t}) 0x{v}\n".format(
+                return "  {k} ({key_name}): ({len} bytes/{t}) 0x{v} {value_description}\n".format(
                     k=entry_key,
                     key_name=name,
                     v=entry_value.hex(),
                     len=len(entry_value),
                     t=type(entry_value),
+                    value_description=value_description,
                 )
-            return "  {k} ({key_name}): ({len} bytes/{t}) {v}\n".format(
+            return "  {k} ({key_name}): ({len} bytes/{t}) {v} {value_description}\n".format(
                 k=entry_key,
                 key_name=name,
                 v=entry_value,
                 len=len(entry_value),
                 t=type(entry_value),
+                value_description=value_description,
             )
 
         if isinstance(d, dict):

--- a/tests/test_protocol_tlv.py
+++ b/tests/test_protocol_tlv.py
@@ -124,7 +124,7 @@ class TestTLV(unittest.TestCase):
             ),
         ]
         res = TLV.to_string(example)
-        self.assertEqual(res, "[\n  1: (5 bytes/<class 'str'>) hello\n]\n")
+        self.assertEqual(res, "[\n  1 (Identifier): (5 bytes/<class 'str'>) hello\n]\n")
         example = [
             (
                 1,
@@ -138,29 +138,29 @@ class TestTLV(unittest.TestCase):
         res = TLV.to_string(example)
         self.assertEqual(
             res,
-            "[\n  1: (5 bytes/<class 'str'>) hello\n  2: (5 bytes/<class 'str'>) world\n]\n",
+            "[\n  1 (Identifier): (5 bytes/<class 'str'>) hello\n  2 (Salt): (5 bytes/<class 'str'>) world\n]\n",
         )
 
     def test_to_string_for_dict(self):
         example = {1: "hello"}
         res = TLV.to_string(example)
-        self.assertEqual(res, "{\n  1: (5 bytes/<class 'str'>) hello\n}\n")
+        self.assertEqual(res, "{\n  1 (Identifier): (5 bytes/<class 'str'>) hello\n}\n")
         example = {1: "hello", 2: "world"}
         res = TLV.to_string(example)
         self.assertEqual(
             res,
-            "{\n  1: (5 bytes/<class 'str'>) hello\n  2: (5 bytes/<class 'str'>) world\n}\n",
+            "{\n  1 (Identifier): (5 bytes/<class 'str'>) hello\n  2 (Salt): (5 bytes/<class 'str'>) world\n}\n",
         )
 
     def test_to_string_for_dict_bytearray(self):
         example = {1: bytearray([0x42, 0x23])}
         res = TLV.to_string(example)
-        self.assertEqual(res, "{\n  1: (2 bytes/<class 'bytearray'>) 0x4223\n}\n")
+        self.assertEqual(res, "{\n  1 (Identifier): (2 bytes/<class 'bytearray'>) 0x4223\n}\n")
 
     def test_to_string_for_list_bytearray(self):
         example = [[1, bytearray([0x42, 0x23])]]
         res = TLV.to_string(example)
-        self.assertEqual(res, "[\n  1: (2 bytes/<class 'bytearray'>) 0x4223\n]\n")
+        self.assertEqual(res, "[\n  1 (Identifier): (2 bytes/<class 'bytearray'>) 0x4223\n]\n")
 
     def test_separator_list(self):
         val = [

--- a/tests/test_protocol_tlv.py
+++ b/tests/test_protocol_tlv.py
@@ -155,12 +155,16 @@ class TestTLV(unittest.TestCase):
     def test_to_string_for_dict_bytearray(self):
         example = {1: bytearray([0x42, 0x23])}
         res = TLV.to_string(example)
-        self.assertEqual(res, "{\n  1 (Identifier): (2 bytes/<class 'bytearray'>) 0x4223\n}\n")
+        self.assertEqual(
+            res, "{\n  1 (Identifier): (2 bytes/<class 'bytearray'>) 0x4223\n}\n"
+        )
 
     def test_to_string_for_list_bytearray(self):
         example = [[1, bytearray([0x42, 0x23])]]
         res = TLV.to_string(example)
-        self.assertEqual(res, "[\n  1 (Identifier): (2 bytes/<class 'bytearray'>) 0x4223\n]\n")
+        self.assertEqual(
+            res, "[\n  1 (Identifier): (2 bytes/<class 'bytearray'>) 0x4223\n]\n"
+        )
 
     def test_separator_list(self):
         val = [


### PR DESCRIPTION
Trying to work out 
https://github.com/Jc2k/aiohomekit/issues/136

This make it a bit easier to read
```
2022-08-07 12:40:15.282 DEBUG (MainThread) [aiohomekit.controller.ip.connection] 192.168.107.127: raw response: bytearray(b'\x06\x01\x02\x03 \xa41\xbc\x82\xce\x8a\x13,e/#Cw\xa7:\xcb\x0c\x08\xee9\xf2\xb1\xfaB\xc3\xd4\xa0O\xf1\x14\xa6\x00\x05e\x9c\xccs\x13\x85\xf4\xba\xb6\x9f"\xcc\xf1\xe3a\xbd+\xc9\x9f\xfe\x12c+\xd1\x03tg\xed\xc1\xde\xe3\xefo\xc6Ur\xb3\r\xee;\xde\xd6\x06\xeb`\xb9%\xa1\r\xfc\xb6\xdb4C+c\x1c\xb6^\x18\x85>\xfc\x14=\r\x93e\x91ON_~\xd5\xe7du&\xc4\xe2\xc2g\xbc\xc5\xb6u\x95\xb7\x1a\x1f\x8bN\x08\xe5\x89\xcd\x0f\x18\xa8\xc0\xf7}')
2022-08-07 12:40:15.283 DEBUG (MainThread) [aiohomekit.protocol.tlv] receiving [
  6 (State): (1 bytes/<class 'bytearray'>) 0x02
  3 (PublicKey): (32 bytes/<class 'bytearray'>) 0xa431bc82ce8a132c652f234377a73acb0c08ee39f2b1fa42c3d4a04ff114a600
  5 (EncryptedData): (101 bytes/<class 'bytearray'>) 0x9ccc731385f4bab69f22ccf1e361bd2bc99ffe12632bd1037467edc1dee3ef6fc65572b30dee3bded606eb60b925a10dfcb6db34432b631cb65e18853efc143d0d9365914f4e5f7ed5e7647526c4e2c267bcc5b67595b71a1f8b4e08e589cd0f18a8c0f77d
]

2022-08-07 12:40:15.286 DEBUG (MainThread) [aiohomekit.protocol.tlv] receiving [
  1 (Identifer): (17 bytes/<class 'bytearray'>) 0x38433a34373a37353a33303a33303a3536
  10 (Signature): (64 bytes/<class 'bytearray'>) 0x6fbcb7b00fa048860fc04780b85b6469eb7217d5d46cdde34713e431cd1daed1e184897a0f5bd789d3080e78044b23b6af11b22987efebc699fe4b936b932b00
]

2022-08-07 12:40:15.288 DEBUG (MainThread) [aiohomekit.protocol.tlv] sending [
  1 (Identifer): (36 bytes/<class 'bytes'>) b'7f953234-1f78-4e23-9ab1-779efa8c90aa'
  10 (Signature): (64 bytes/<class 'bytes'>) b'~\x1e\x9bW\xe3lk\xc2\xac\x9a\xd5\xf9)/\xdaa\xbe\xf1\t\x97\xefmB\xbc\x18\x94\x0e\x07\xec.\xd8[\x03\xa8\x186\xbb\xc6\x92\x04\xe8\x06\xd6\x84\xacD\xe0\xb6\x02\xc0\xbfW\xc0\x9bDo\xd6\x08zn\xa1-\x1c\t'
]

2022-08-07 12:40:15.289 DEBUG (MainThread) [aiohomekit.protocol.tlv] sending [
  6 (State): (1 bytes/<class 'bytearray'>) 0x03
  5 (EncryptedData): (120 bytes/<class 'bytes'>) b"\x19c\x00\x1c\x17\xcf\xd5\xa1\xafb?\xb5\xcd\xcd\xd8!\xcfp\xe0T\xea:\xda\xddy\xff\xda\xe2\x8di\xa3\xc4\xbc\xd0\xe6{\x1a\xdc\xd3\xf4\xf1\xdc\xbe8b\x91/\xa3\xec\xd0\xa4v9\xd8b\x89v\x8f\xa2\x92\xdc\x97D\xe5\xfd\xde\xd8p\xd8\x83\n\xb9\x96\xe7'k}\xb3F@\x8cm\x10\x8d\x9eY\xedr\xc9j\xfa\x0c\x8e\xeb]j\xb0\xd7\x14\xe1\x11\xccw\xe8[n-\xe7\x9f\x9e\xe4\xb6\x88\x9a\xbf\x80&TL\x1d"
]
```