### PR TITLE
Add support for bleak max_write_without_response_size and current bleak MTU

### DIFF
--- a/aiohomekit/controller/ble/bleak.py
+++ b/aiohomekit/controller/ble/bleak.py
@@ -43,7 +43,7 @@ class AIOHomeKitBleakClient(BleakClient):
         iid_handle = char.get_descriptor(CHAR_DESCRIPTOR_UUID)
         if iid_handle is None:
             return None
-        value = bytes(await self.read_gatt_descriptor(iid_handle.handle))
+        value = bytes(await self.read_gatt_descriptor(iid_handle))
         iid = int.from_bytes(value, byteorder="little")
         self._iid_cache[char] = iid
         return iid

--- a/aiohomekit/controller/ble/bleak.py
+++ b/aiohomekit/controller/ble/bleak.py
@@ -43,7 +43,7 @@ class AIOHomeKitBleakClient(BleakClient):
         iid_handle = char.get_descriptor(CHAR_DESCRIPTOR_UUID)
         if iid_handle is None:
             return None
-        value = bytes(await self.read_gatt_descriptor(iid_handle))
+        value = bytes(await self.read_gatt_descriptor(iid_handle.handle))
         iid = int.from_bytes(value, byteorder="little")
         self._iid_cache[char] = iid
         return iid

--- a/aiohomekit/controller/ble/client.py
+++ b/aiohomekit/controller/ble/client.py
@@ -103,6 +103,11 @@ async def ble_request(
         and isinstance(char_obj, dict)
         and (char_mtu := char_obj.get("MTU"))
     ):
+        logger.debug(
+            "bleak obj MTU: %s, mtu_size-3: %s",
+            char_mtu,
+            client.mtu_size - 3,
+        )
         fragment_size = max(char_mtu - 3, client.mtu_size - 3)
     else:
         logger.debug(

--- a/aiohomekit/controller/ble/client.py
+++ b/aiohomekit/controller/ble/client.py
@@ -86,6 +86,8 @@ async def ble_request(
     # We think there is a 3 byte overhead for ATT
     # https://github.com/jlusiardi/homekit_python/issues/211#issuecomment-996751939
     # But we haven't confirmed that this isn't already taken into account
+
+    # Newer bleak, not currently released
     if max_write_without_response_size := getattr(
         handle, "max_write_without_response_size", None
     ):
@@ -95,6 +97,13 @@ async def ble_request(
             client.mtu_size - 3,
         )
         fragment_size = max(max_write_without_response_size, client.mtu_size - 3)
+    # Bleak 0.15.1 and below
+    elif (
+        (char_obj := getattr(handle, "obj", None))
+        and isinstance(char_obj, dict)
+        and (char_mtu := char_obj.get("MTU"))
+    ):
+        fragment_size = max(char_mtu - 3, client.mtu_size - 3)
     else:
         logger.debug(
             "no max_write_without_response_size, using mtu_size-3: %s",

--- a/aiohomekit/controller/ble/client.py
+++ b/aiohomekit/controller/ble/client.py
@@ -15,12 +15,13 @@
 #
 
 from __future__ import annotations
-from bleak.backends.characteristic import BleakGATTCharacteristic
+
 import logging
 import random
 from typing import Any, Callable, TypeVar, cast
 
 from bleak import BleakClient
+from bleak.backends.characteristic import BleakGATTCharacteristic
 
 from aiohomekit.controller.ble.key import DecryptionKey, EncryptionKey
 from aiohomekit.exceptions import EncryptionError

--- a/aiohomekit/controller/ble/discovery.py
+++ b/aiohomekit/controller/ble/discovery.py
@@ -111,7 +111,7 @@ class BleDiscovery(AbstractDiscovery):
             CharacteristicsTypes.PAIRING_FEATURES,
         )
         ff_iid = await self.client.get_characteristic_iid(ff_char)
-        ff_raw = await char_read(self.client, None, None, ff_char.handle, ff_iid)
+        ff_raw = await char_read(self.client, None, None, ff_char, ff_iid)
         ff = FeatureFlags(ff_raw[0])
         return await drive_pairing_state_machine(
             self.client,
@@ -182,7 +182,7 @@ class BleDiscovery(AbstractDiscovery):
         )
         iid = await self.client.get_characteristic_iid(char)
 
-        await char_write(self.client, None, None, char.handle, iid, b"\x01")
+        await char_write(self.client, None, None, char, iid, b"\x01")
 
     def _async_process_advertisement(
         self, device: BLEDevice, description: HomeKitAdvertisement

--- a/aiohomekit/controller/ble/pairing.py
+++ b/aiohomekit/controller/ble/pairing.py
@@ -276,7 +276,7 @@ class BlePairing(AbstractPairing):
             self._encryption_key,
             self._decryption_key,
             opcode,
-            endpoint.handle,
+            endpoint,
             char.iid,
             data,
         )
@@ -448,12 +448,12 @@ class BlePairing(AbstractPairing):
                     iid,
                 ):
                     await self.client.write_gatt_char(
-                        char.handle,
+                        char,
                         data,
                         "write-without-response" not in char.properties,
                     )
 
-                payload = await self.client.read_gatt_char(char.handle)
+                payload = await self.client.read_gatt_char(char)
 
                 status, _, signature = decode_pdu(tid, payload)
                 if status != PDUStatus.SUCCESS:


### PR DESCRIPTION
This is working with the current version of bleak as well and restores the performance that was lost in https://github.com/Jc2k/aiohomekit/pull/139

Also drops `.handle` calls since https://github.com/hbldh/bleak/issues/888

Needs https://github.com/hbldh/bleak/pull/930 for `max_write_without_response_size` but we can already get the MTU since the dict is accessible already.