### PR TITLE
Fix regression in aiohomekit 1.0.0 where IP/port changes are not picked up

### DIFF
--- a/aiohomekit/controller/ble/structs.py
+++ b/aiohomekit/controller/ble/structs.py
@@ -16,7 +16,7 @@
 from dataclasses import dataclass, field
 import enum
 import struct
-from typing import Any, Optional, Tuple, Union
+from typing import Any, Optional, Union
 
 from aiohomekit.tlv8 import TLVStruct, tlv_entry, u8, u16, u128
 
@@ -249,7 +249,7 @@ class Characteristic(TLVStruct):
         return self._unpack_value(self.step_value)
 
     @property
-    def min_max_value(self) -> Optional[Tuple[Union[int, float], Union[int, float]]]:
+    def min_max_value(self) -> Optional[tuple[Union[int, float], Union[int, float]]]:
         if not self.valid_range:
             return None
         if self.pf_format == 0x04:

--- a/aiohomekit/controller/ip/connection.py
+++ b/aiohomekit/controller/ip/connection.py
@@ -16,7 +16,7 @@
 
 import asyncio
 import logging
-from aiohomekit.controller.ip.controller import IpController
+from typing import TYPE_CHECKING
 
 from aiohomekit.crypto.chacha20poly1305 import (
     ChaCha20Poly1305Decryptor,
@@ -39,6 +39,9 @@ from aiohomekit.protocol.tlv import TLV
 from aiohomekit.utils import async_create_task
 
 logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from aiohomekit.controller.ip.controller import IpController
 
 
 class InsecureHomeKitProtocol(asyncio.Protocol):
@@ -600,13 +603,23 @@ class SecureHomeKitConnection(HomeKitConnection):
         if self.owner:
             controller: IpController = self.owner.controller
             try:
-                discovery = await controller.async_find(self.pairing_data["AccessoryPairingID"])
+                discovery = await controller.async_find(
+                    self.pairing_data["AccessoryPairingID"]
+                )
                 if self.host != discovery.description.address:
-                    logger.debug("Host changed from %s to %s", self.host, self.discovery.description.address)
+                    logger.debug(
+                        "Host changed from %s to %s",
+                        self.host,
+                        self.discovery.description.address,
+                    )
                     self.host = discovery.description.address
 
                 if self.port != discovery.description.port:
-                    logger.debug("Port changed from %s to %s", self.port, self.discovery.description.port)
+                    logger.debug(
+                        "Port changed from %s to %s",
+                        self.port,
+                        self.discovery.description.port,
+                    )
                     self.port = discovery.description.port
             except AccessoryNotFoundError:
                 pass

--- a/aiohomekit/controller/ip/connection.py
+++ b/aiohomekit/controller/ip/connection.py
@@ -610,7 +610,7 @@ class SecureHomeKitConnection(HomeKitConnection):
                     logger.debug(
                         "Host changed from %s to %s",
                         self.host,
-                        self.discovery.description.address,
+                        discovery.description.address,
                     )
                     self.host = discovery.description.address
 
@@ -618,7 +618,7 @@ class SecureHomeKitConnection(HomeKitConnection):
                     logger.debug(
                         "Port changed from %s to %s",
                         self.port,
-                        self.discovery.description.port,
+                        discovery.description.port,
                     )
                     self.port = discovery.description.port
             except AccessoryNotFoundError:

--- a/aiohomekit/zeroconf.py
+++ b/aiohomekit/zeroconf.py
@@ -146,7 +146,7 @@ class ZeroconfController(AbstractController):
         # FIXME: Detach from zeroconf instance
         pass
 
-    async def async_find(self, device_id: str) -> AbstractDiscovery:
+    async def async_find(self, device_id: str) -> ZeroconfDiscovery:
         device_id = device_id.lower()
 
         async for device in self.async_discover():
@@ -155,7 +155,7 @@ class ZeroconfController(AbstractController):
 
         raise AccessoryNotFoundError(f"Accessory with device id {device_id} not found")
 
-    async def async_discover(self) -> AsyncIterable[AbstractDiscovery]:
+    async def async_discover(self) -> AsyncIterable[ZeroconfDiscovery]:
         zc = self._async_zeroconf_instance.zeroconf
         infos = [
             AsyncServiceInfo(self.hap_type, record.alias)


### PR DESCRIPTION
The original plan for aiohomekit 1.0 was going to be that we attched to the zeroconf instance in the ZeroconfController and notified pairings when it spotted the ip/port changing. This was pushed back, so this needs restoring for now.