### PR TITLE
Implement bluetooth service caching

### DIFF
--- a/aiohomekit/controller/ble/bleak.py
+++ b/aiohomekit/controller/ble/bleak.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 import uuid
 
-from bleak import BleakClient, BleakError
+from bleak import BleakError
 from bleak.backends.characteristic import BleakGATTCharacteristic
 from bleak.backends.device import BLEDevice
+from bleak_retry_connector import BleakClientWithServiceCache
 
 from .const import HAP_MIN_REQUIRED_MTU
 
@@ -13,7 +14,7 @@ CHAR_DESCRIPTOR_ID = "DC46F0FE-81D2-4616-B5D9-6ABDD796939A"
 CHAR_DESCRIPTOR_UUID = uuid.UUID(CHAR_DESCRIPTOR_ID)
 
 
-class AIOHomeKitBleakClient(BleakClient):
+class AIOHomeKitBleakClient(BleakClientWithServiceCache):
     """Wrapper for bleak.BleakClient that auto discovers the max mtu."""
 
     def __init__(self, address_or_ble_device: BLEDevice | str) -> None:

--- a/aiohomekit/controller/ble/connection.py
+++ b/aiohomekit/controller/ble/connection.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 from collections.abc import Callable
 
 from bleak.backends.device import BLEDevice
+from bleak.backends.service import BleakGATTServiceCollection
 from bleak_retry_connector import (
     BleakAbortedError,
     BleakConnectionError,
@@ -39,6 +40,7 @@ async def establish_connection(
     name: str,
     disconnected_callback: Callable[[AIOHomeKitBleakClient], None],
     max_attempts: int = MAX_CONNECT_ATTEMPTS,
+    cached_services: BleakGATTServiceCollection | None = None,
 ) -> AIOHomeKitBleakClient:
     """Establish a connection to the accessory."""
     try:
@@ -48,6 +50,7 @@ async def establish_connection(
             name,
             disconnected_callback,
             max_attempts=max_attempts,
+            cached_services=cached_services,
         )
     except (BleakAbortedError, BleakConnectionError) as ex:
         raise AccessoryDisconnectedError(ex) from ex

--- a/poetry.lock
+++ b/poetry.lock
@@ -121,7 +121,7 @@ uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
 name = "bleak"
-version = "0.14.3"
+version = "0.15.1"
 description = "Bluetooth Low Energy platform Agnostic Klient"
 category = "main"
 optional = false
@@ -133,10 +133,11 @@ dbus-next = {version = "*", markers = "platform_system == \"Linux\""}
 pyobjc-core = {version = "*", markers = "platform_system == \"Darwin\""}
 pyobjc-framework-CoreBluetooth = {version = "*", markers = "platform_system == \"Darwin\""}
 pyobjc-framework-libdispatch = {version = "*", markers = "platform_system == \"Darwin\""}
+typing-extensions = ">=4.2.0"
 
 [[package]]
 name = "bleak-retry-connector"
-version = "1.5.0"
+version = "1.7.0"
 description = "A connector for Bleak Clients that handles transient connection failures"
 category = "main"
 optional = false
@@ -144,7 +145,7 @@ python-versions = ">=3.9,<4.0"
 
 [package.dependencies]
 async-timeout = ">=4.0.1"
-bleak = ">=0.14.3"
+bleak = ">=0.15.1"
 
 [package.extras]
 docs = ["sphinx-rtd-theme (>=1.0,<2.0)", "myst-parser (>=0.18,<0.19)", "Sphinx (>=5.0,<6.0)"]
@@ -698,7 +699,7 @@ python-versions = ">=3.6,<4.0"
 name = "typing-extensions"
 version = "4.3.0"
 description = "Backported and Experimental Type Hints for Python 3.7+"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 
@@ -749,7 +750,7 @@ ifaddr = ">=0.1.7"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "02d4e3f16b140ea6476f0ab44562a76534582960ec67fe3d551106844a4d3b33"
+content-hash = "12be644545d6f7b626fbe121721d455d203d53c4a8755041c77f381174a51310"
 
 [metadata.files]
 aiocoap = [
@@ -879,12 +880,12 @@ black = [
     {file = "black-22.6.0.tar.gz", hash = "sha256:6c6d39e28aed379aec40da1c65434c77d75e65bb59a1e1c283de545fb4e7c6c9"},
 ]
 bleak = [
-    {file = "bleak-0.14.3-py2.py3-none-any.whl", hash = "sha256:1740c09039e58a65023a3c7141609bff1300dff2b5f7ab103a3218063803e965"},
-    {file = "bleak-0.14.3.tar.gz", hash = "sha256:760e5bb1e804087f762576b9b9563d63b47d521b1652988e28c3cb5e64b61990"},
+    {file = "bleak-0.15.1-py2.py3-none-any.whl", hash = "sha256:af90ac301a723433460cb56215dd00f687281fa397395c2faadd9e59741ba3b4"},
+    {file = "bleak-0.15.1.tar.gz", hash = "sha256:d8c8d88de0f22a15bd135ba056c4e5b2fb9f15119283def21b1ed7d43c00d590"},
 ]
 bleak-retry-connector = [
-    {file = "bleak-retry-connector-1.5.0.tar.gz", hash = "sha256:e12773df9b663149843d5ebf40cd808ccaa804939fdf5dfdc1c76d495849e5bb"},
-    {file = "bleak_retry_connector-1.5.0-py3-none-any.whl", hash = "sha256:a66a5beb2a9b52592d5f9b3df90f073ba449699fda5271d44ad428f53edbe925"},
+    {file = "bleak-retry-connector-1.7.0.tar.gz", hash = "sha256:8d2448ae8db42bab01d7ba510430dee60a2c63a3fb21df60d5e935d00f9da489"},
+    {file = "bleak_retry_connector-1.7.0-py3-none-any.whl", hash = "sha256:b77ac37e62cab42ac299ce9d286de981547ca4dfb666b097a520356fa9a0e9ba"},
 ]
 bleak-winrt = [
     {file = "bleak-winrt-1.1.1.tar.gz", hash = "sha256:3e7765f98d71b5229d95bd3b197931994dead40f3144e7186de7b8f664e26df0"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ commentjson = "^0.9.0"
 aiocoap = ">=0.4.1"
 bleak = ">=0.14.2"
 chacha20poly1305-reuseable = ">=0.0.4"
-bleak-retry-connector = ">=1.5.0"
+bleak-retry-connector = ">=1.7.0"
 orjson = ">=3.7.8"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
We now cache the services when reconnecting to reduce the time before we can start talking to the accessory.

The cache is never used when we need to fetch the GATT database or the ble device has changed
between connections.

The naïve address check has been replaced with the `ble_device_has_changed` helper which knows about
adapter changes.