### PR TITLE
Fix missing padding in SRP

### DIFF
--- a/aiohomekit/crypto/srp.py
+++ b/aiohomekit/crypto/srp.py
@@ -22,7 +22,6 @@ from __future__ import annotations
 import hashlib
 import math
 import os
-from sys import int_info
 from typing import Iterable
 
 # The K value for HK SRP is always the same because G and N are fixed

--- a/aiohomekit/crypto/srp.py
+++ b/aiohomekit/crypto/srp.py
@@ -116,14 +116,17 @@ class Srp:
         u = int.from_bytes(self.digest(self.A_b, self.B_b), "big")
         return u
 
+    def get_shared_secret_bytes(self) -> bytes:
+        """Returns the shared secret as bytes."""
+        return pad_left(Srp.to_byte_array(self.get_shared_secret()), HK_KEY_LENGTH)
+
     def get_session_key_bytes(self) -> bytes:
         """Returns the session key as bytes."""
-        return pad_left(Srp.to_byte_array(self.get_shared_secret()), HK_KEY_LENGTH)
+        return self.digest(self.get_shared_secret_bytes())
 
     def get_session_key(self) -> int:
         """Return the K value for the session key."""
-        S_b = self.get_session_key_bytes()
-        return int.from_bytes(self.digest(S_b), "big")
+        return int.from_bytes(self.get_session_key_bytes(), "big")
 
     @staticmethod
     def to_byte_array(num: int) -> bytearray:

--- a/aiohomekit/crypto/srp.py
+++ b/aiohomekit/crypto/srp.py
@@ -113,8 +113,7 @@ class Srp:
     def _calculate_u(self) -> int:
         """Returns the U value."""
         self._assert_public_keys()
-        u = int.from_bytes(self.digest(self.A_b, self.B_b), "big")
-        return u
+        return int.from_bytes(self.digest(self.A_b, self.B_b), "big")
 
     def get_shared_secret_bytes(self) -> bytes:
         """Returns the shared secret as bytes."""

--- a/aiohomekit/crypto/srp.py
+++ b/aiohomekit/crypto/srp.py
@@ -247,10 +247,13 @@ class SrpServer(Srp):
         v = pow(self.g, hash_value, self.n)
         return v
 
-    def set_client_public_key(self, A_b: bytes | bytearray) -> None:
-        assert isinstance(A_b, (bytes, bytearray)), "The public key must be a bytes"
-        self.A_b = A_b
-        self.A = int.from_bytes(A_b, "big")
+    def set_client_public_key(self, pub_key: int | bytes | bytearray) -> None:
+        if isinstance(int, pub_key):
+            self.A = pub_key
+            self.A_b = pad_left(to_byte_array(self.A), HK_KEY_LENGTH)
+        else:
+            self.A_b = pub_key
+            self.A = int.from_bytes(pub_key, "big")
 
     def get_salt(self) -> int:
         return self.salt

--- a/aiohomekit/crypto/srp.py
+++ b/aiohomekit/crypto/srp.py
@@ -107,12 +107,7 @@ class Srp:
             raise RuntimeError("Client's public key is missing")
         if self.B_b is None:
             raise RuntimeError("Server's public key is missing")
-        A_b = Srp.to_byte_array(self.A)  # client's public key as bytes
-        B_b = Srp.to_byte_array(self.B)  # server's public key as bytes
-        assert len(A_b) == HK_KEY_LENGTH
-        assert len(B_b) == HK_KEY_LENGTH
-        u = int.from_bytes(self.digest(A_b, B_b), "big")
-        return u
+        return int.from_bytes(self.digest(self.A_b, self.B_b), "big")
 
     def get_session_key(self) -> int:
         """Return the K value for the session key."""
@@ -234,7 +229,7 @@ class SrpServer(Srp):
         k = self._calculate_k()
         g_b = pow(self.g, self.b, self.n)
         self.B = (k * self.verifier + g_b) % self.n
-        self.B_b = pad_left(to_byte_array(self.b), HK_KEY_LENGTH)  # public key as bytes
+        self.B_b = pad_left(to_byte_array(self.B), HK_KEY_LENGTH)  # public key as bytes
         self.A = None
 
     @staticmethod
@@ -256,11 +251,10 @@ class SrpServer(Srp):
         return self.salt
 
     def get_public_key(self) -> int:
-        k = self._calculate_k()
-        return (k * self.verifier + pow(self.g, self.b, self.n)) % self.n
+        return self.B
 
     def get_public_key_bytes(self) -> bytes:
-        return pad_left(to_byte_array(self.get_public_key()), HK_KEY_LENGTH)
+        return self.B_b
 
     def get_shared_secret(self) -> int:
         if self.A_b is None:

--- a/aiohomekit/crypto/srp.py
+++ b/aiohomekit/crypto/srp.py
@@ -78,7 +78,9 @@ H_GROUP = bytes(
 class Srp:
     """HomeKit SRP implementation."""
 
-    def __init__(self) -> None:
+    def __init__(self, username: str, password: str) -> None:
+        self.username = username
+        self.password = password
         self.g = GENERATOR_VALUE  # generator
         self.n = MODULUS_VALUE  # modulus
         self.hGroup = H_GROUP
@@ -150,9 +152,7 @@ class SrpClient(Srp):
     """
 
     def __init__(self, username: str, password: str) -> None:
-        super().__init__()
-        self.username = username
-        self.password = password
+        super().__init__(username, password)
         self.a = self.generate_private_key()  # client's private key
         self.A = pow(self.g, self.a, self.n)  # public key
         self.A_b = pad_left(to_byte_array(self.A), HK_KEY_LENGTH)  # public key as bytes
@@ -227,11 +227,9 @@ class SrpServer(Srp):
     """
 
     def __init__(self, username: str, password: str) -> None:
-        super().__init__()
-        self.username = username
+        super().__init__(username, password)
         self.salt = SrpServer._create_salt()
         self.salt_b = pad_left(to_byte_array(self.salt), 16)
-        self.password = password
         self.verifier = self._get_verifier()
         self.b = self.generate_private_key()
         k = self._calculate_k()

--- a/aiohomekit/crypto/srp.py
+++ b/aiohomekit/crypto/srp.py
@@ -248,7 +248,7 @@ class SrpServer(Srp):
         return v
 
     def set_client_public_key(self, pub_key: int | bytes | bytearray) -> None:
-        if isinstance(int, pub_key):
+        if isinstance(pub_key, int):
             self.A = pub_key
             self.A_b = pad_left(to_byte_array(self.A), HK_KEY_LENGTH)
         else:

--- a/aiohomekit/crypto/srp.py
+++ b/aiohomekit/crypto/srp.py
@@ -233,8 +233,8 @@ class SrpServer(Srp):
 
     def __init__(self, username: str, password: str) -> None:
         super().__init__(username, password)
-        self.salt = SrpServer._create_salt()
-        self.salt_b = pad_left(to_byte_array(self.salt), 16)
+        self.salt_b = self._create_salt_bytes()
+        self.salt = int.from_bytes(self.salt_b, "big")
         self.verifier = self._get_verifier()
         self.b = self.generate_private_key()
         k = self._calculate_k()
@@ -243,10 +243,9 @@ class SrpServer(Srp):
         self.B_b = pad_left(to_byte_array(self.B), HK_KEY_LENGTH)  # public key as bytes
         self.A = None
 
-    @staticmethod
-    def _create_salt() -> int:
+    def _create_salt_bytes(self) -> bytes:
         # generate random salt
-        return int.from_bytes(os.urandom(16), byteorder="big")
+        return os.urandom(16)
 
     def _get_verifier(self) -> int:
         hash_value = self._calculate_client_password_x()

--- a/aiohomekit/crypto/srp.py
+++ b/aiohomekit/crypto/srp.py
@@ -147,8 +147,7 @@ class SrpClient(Srp):
         self.password = password
         self.a = self.generate_private_key()  # client's private key
         self.A = pow(self.g, self.a, self.n)  # public key
-        self.A_b = to_byte_array(self.A)  # public key as bytes
-        assert len(self.A_b) == HK_KEY_LENGTH  # public key must be 384 bytes long
+        self.A_b = pad_left(to_byte_array(self.A), HK_KEY_LENGTH)  # public key as bytes
         self.k = self._calculate_k()  # static k value
         self.B = None  # server's public key
         self.B_b: bytearray | None = None  # server's public key as bytes
@@ -165,13 +164,10 @@ class SrpClient(Srp):
     def get_public_key(self) -> int:
         return self.A
 
-    def set_server_public_key(self, B: int | bytearray) -> None:
-        if isinstance(B, bytearray):
-            self.B = int.from_bytes(B, "big")
-        else:
-            self.B = B
-        self.B_b = to_byte_array(self.B)
-        assert len(self.B_b) == HK_KEY_LENGTH
+    def set_server_public_key(self, B_b: bytearray | bytes) -> None:
+        assert isinstance(B_b, (bytes, bytearray)), "The public key must be a bytes"
+        self.B_b = B_b
+        self.B = int.from_bytes(B_b, "big")
 
     def get_shared_secret(self) -> int:
         if self.B is None:

--- a/aiohomekit/crypto/srp.py
+++ b/aiohomekit/crypto/srp.py
@@ -183,8 +183,8 @@ class SrpClient(Srp):
         """Get the proof/M value."""
         if self.B is None:
             raise RuntimeError("Server's public key is missing")
-        hN = bytearray(self.digest(to_byte_array(self.n)))  # H(modulus)
-        hg = bytearray(self.digest(to_byte_array(self.g)))  # H(generator)
+        hN = self.digest(to_byte_array(self.n))  # H(modulus)
+        hg = self.digest(to_byte_array(self.g))  # H(generator)
         hGroup = bytes(
             hN[i] ^ hg[i] for i in range(0, len(hN))
         )  # H(modulus) xor H(generator)

--- a/aiohomekit/crypto/srp.py
+++ b/aiohomekit/crypto/srp.py
@@ -154,7 +154,7 @@ class SrpClient(Srp):
         self.B = None  # server's public key
         self.B_b: bytearray | None = None  # server's public key as bytes
 
-    def set_salt(self, salt: Union[int, bytearray]) -> None:
+    def set_salt(self, salt: int | bytearray) -> None:
         if isinstance(salt, bytearray):
             self.salt = int.from_bytes(salt, "big")
         else:
@@ -166,7 +166,7 @@ class SrpClient(Srp):
     def get_public_key(self) -> int:
         return self.A
 
-    def set_server_public_key(self, B: Union[int, bytearray]) -> None:
+    def set_server_public_key(self, B: int | bytearray) -> None:
         if isinstance(B, bytearray):
             self.B = int.from_bytes(B, "big")
         else:
@@ -205,7 +205,7 @@ class SrpClient(Srp):
         )
         return int.from_bytes(proof, "big")
 
-    def verify_servers_proof(self, M: Union[int, bytearray]) -> bool:
+    def verify_servers_proof(self, M: int | bytearray) -> bool:
         if isinstance(M, bytearray):
             tmp = int.from_bytes(M, "big")
         else:

--- a/aiohomekit/crypto/srp.py
+++ b/aiohomekit/crypto/srp.py
@@ -292,12 +292,10 @@ class SrpServer(Srp):
         )
 
     def get_proof_bytes(self, m: int) -> bytes:
-        return (
-            self.digest(
-                self.A_b,
-                to_byte_array(m),
-                self.get_session_key_bytes(),
-            ),
+        return self.digest(
+            self.A_b,
+            to_byte_array(m),
+            self.get_session_key_bytes(),
         )
 
     def get_proof(self, m: int) -> int:

--- a/aiohomekit/crypto/srp.py
+++ b/aiohomekit/crypto/srp.py
@@ -216,8 +216,8 @@ class SrpClient(Srp):
             tmp = M
         return tmp == int.from_bytes(
             self.digest(
-                self.A_b,
-                self.get_proof_bytes(),
+                to_byte_array(self.A),
+                to_byte_array(self.get_proof()),
                 self.get_session_key_bytes(),
             ),
             "big",
@@ -292,7 +292,7 @@ class SrpServer(Srp):
     def get_proof(self, m: int) -> int:
         return int.from_bytes(
             self.digest(
-                self.A_b,
+                to_byte_array(self.A),
                 to_byte_array(m),
                 self.get_session_key_bytes(),
             ),

--- a/aiohomekit/crypto/srp.py
+++ b/aiohomekit/crypto/srp.py
@@ -121,11 +121,7 @@ class Srp:
 
     def get_session_key_bytes(self) -> bytes:
         """Return the K value for the session key."""
-        return pad_left(Srp.to_byte_array(self.get_shared_secret()), HK_KEY_LENGTH)
-
-    @staticmethod
-    def to_byte_array(num: int) -> bytearray:
-        return to_byte_array(num)
+        return pad_left(to_byte_array(self.get_shared_secret()), HK_KEY_LENGTH)
 
     def _calculate_client_password_x(self) -> int:
         """Calculate the x value for the client's password."""
@@ -154,7 +150,7 @@ class SrpClient(Srp):
         self.A = pow(self.g, self.a, self.n)  # public key
         self.A_b = pad_left(to_byte_array(self.A), HK_KEY_LENGTH)  # public key as bytes
 
-    def set_salt(self, salt: bytearray) -> None:
+    def set_salt_bytes(self, salt: bytearray) -> None:
         assert isinstance(salt, (bytes, bytearray))
         self.salt_b = salt
         self.salt = int.from_bytes(salt, "big")
@@ -163,7 +159,7 @@ class SrpClient(Srp):
     def get_public_key_bytes(self) -> bytes:
         return self.A_b
 
-    def set_server_public_key(self, B_b: bytearray | bytes) -> None:
+    def set_server_public_key_bytes(self, B_b: bytearray | bytes) -> None:
         assert isinstance(B_b, (bytes, bytearray)), "The public key must be a bytes"
         self.B_b = B_b
         self.B = int.from_bytes(B_b, "big")

--- a/aiohomekit/crypto/srp.py
+++ b/aiohomekit/crypto/srp.py
@@ -118,7 +118,6 @@ class Srp:
     def get_session_key(self) -> int:
         """Return the K value for the session key."""
         S_b = Srp.to_byte_array(self.get_shared_secret())
-        assert len(S_b) == HK_KEY_LENGTH
         return int.from_bytes(self.digest(S_b), "big")
 
     @staticmethod

--- a/aiohomekit/crypto/srp.py
+++ b/aiohomekit/crypto/srp.py
@@ -20,9 +20,9 @@ https://tools.ietf.org/html/rfc5054. See HomeKit spec page 36 for adjustments im
 from __future__ import annotations
 
 import hashlib
+import logging
 import math
 import os
-import logging
 from typing import Iterable, Union
 
 # The K value for HK SRP is always the same because G and N are fixed

--- a/aiohomekit/crypto/srp.py
+++ b/aiohomekit/crypto/srp.py
@@ -148,7 +148,7 @@ class SrpClient(Srp):
         self.a = self.generate_private_key()  # client's private key
         self.A = pow(self.g, self.a, self.n)  # public key
         self.A_b = to_byte_array(self.A)  # public key as bytes
-        assert len(self.A_b) == HK_KEY_LENGTH  # public key must be 384 bits long
+        assert len(self.A_b) == HK_KEY_LENGTH  # public key must be 384 bytes long
         self.k = self._calculate_k()  # static k value
         self.B = None  # server's public key
         self.B_b: bytearray | None = None  # server's public key as bytes

--- a/aiohomekit/crypto/srp.py
+++ b/aiohomekit/crypto/srp.py
@@ -220,7 +220,7 @@ class SrpClient(Srp):
         return tmp == int.from_bytes(
             self.digest(
                 self.A_b,
-                to_byte_array(self.get_proof()),
+                self.get_proof_bytes(),
                 self.get_session_key_bytes(),
             ),
             "big",
@@ -292,12 +292,14 @@ class SrpServer(Srp):
             "big",
         )
 
-    def get_proof(self, m: int) -> int:
-        return int.from_bytes(
+    def get_proof_bytes(self, m: int) -> bytes:
+        return (
             self.digest(
                 self.A_b,
                 to_byte_array(m),
                 self.get_session_key_bytes(),
             ),
-            "big",
         )
+
+    def get_proof(self, m: int) -> int:
+        return int.from_bytes(self.get_proof_bytes(m), "big")

--- a/aiohomekit/crypto/srp.py
+++ b/aiohomekit/crypto/srp.py
@@ -20,10 +20,9 @@ https://tools.ietf.org/html/rfc5054. See HomeKit spec page 36 for adjustments im
 from __future__ import annotations
 
 import hashlib
-import logging
 import math
 import os
-from typing import Iterable, Union
+from typing import Iterable
 
 # The K value for HK SRP is always the same because G and N are fixed
 CLIENT_K_VALUE = int(

--- a/aiohomekit/crypto/srp.py
+++ b/aiohomekit/crypto/srp.py
@@ -107,7 +107,11 @@ class Srp:
             raise RuntimeError("Client's public key is missing")
         if self.B_b is None:
             raise RuntimeError("Server's public key is missing")
-        u = int.from_bytes(self.digest(self.A_b, self.B_b), "big")
+        A_b = Srp.to_byte_array(self.A)  # client's public key as bytes
+        B_b = Srp.to_byte_array(self.B)  # server's public key as bytes
+        assert len(A_b) == HK_KEY_LENGTH
+        assert len(B_b) == HK_KEY_LENGTH
+        u = int.from_bytes(self.digest(A_b, B_b), "big")
         return u
 
     def get_session_key(self) -> int:
@@ -280,14 +284,18 @@ class SrpServer(Srp):
 
         hu = self.digest(self.username.encode())
         K = to_byte_array(self.get_session_key())
+        A_b = to_byte_array(self.A)
+        assert len(A_b) == HK_KEY_LENGTH
+        B_b = to_byte_array(self.B)
+        assert len(B_b) == HK_KEY_LENGTH
 
         return m == int.from_bytes(
             self.digest(
                 hGroup,
                 hu,
                 self.salt_b,
-                self.A_b,
-                self.B_b,
+                A_b,
+                B_b,
                 K,
             ),
             "big",

--- a/aiohomekit/crypto/srp.py
+++ b/aiohomekit/crypto/srp.py
@@ -160,9 +160,6 @@ class SrpClient(Srp):
         self.salt = int.from_bytes(salt, "big")
         self.x = self._calculate_client_password_x()
 
-    def get_public_key(self) -> int:
-        return self.A
-
     def get_public_key_bytes(self) -> bytes:
         return self.A_b
 
@@ -234,16 +231,13 @@ class SrpServer(Srp):
         v = pow(self.g, hash_value, self.n)
         return v
 
-    def set_client_public_key(self, A_b: bytes | bytearray) -> None:
+    def set_client_public_key_bytes(self, A_b: bytes | bytearray) -> None:
         assert isinstance(A_b, (bytes, bytearray)), "The public key must be a bytes"
         self.A_b = A_b
         self.A = int.from_bytes(A_b, "big")
 
-    def get_salt(self) -> bytearray:
+    def get_salt_bytes(self) -> bytearray:
         return self.salt_b
-
-    def get_public_key(self) -> int:
-        return self.B
 
     def get_public_key_bytes(self) -> bytes:
         return self.B_b

--- a/aiohomekit/crypto/srp.py
+++ b/aiohomekit/crypto/srp.py
@@ -219,7 +219,7 @@ class SrpClient(Srp):
             tmp = M
         return tmp == int.from_bytes(
             self.digest(
-                to_byte_array(self.A),
+                self.A_b,
                 to_byte_array(self.get_proof()),
                 self.get_session_key_bytes(),
             ),
@@ -295,7 +295,7 @@ class SrpServer(Srp):
     def get_proof(self, m: int) -> int:
         return int.from_bytes(
             self.digest(
-                to_byte_array(self.A),
+                self.A_b,
                 to_byte_array(m),
                 self.get_session_key_bytes(),
             ),

--- a/aiohomekit/crypto/srp.py
+++ b/aiohomekit/crypto/srp.py
@@ -190,10 +190,14 @@ class SrpClient(Srp):
 
     def get_proof(self) -> int:
         """Get the proof/M value."""
+        return int.from_bytes(self.get_proof_bytes(), "big")
+
+    def get_proof_bytes(self) -> bytes:
+        """Get the proof/M value."""
         self._assert_public_keys()
         hu = self.digest(self.username.encode())
         K = to_byte_array(self.get_session_key())  # Session Key
-        proof = self.digest(
+        return self.digest(
             self.hGroup,
             hu,
             self.salt_b,
@@ -201,7 +205,6 @@ class SrpClient(Srp):
             self.B_b,
             K,
         )
-        return int.from_bytes(proof, "big")
 
     def verify_servers_proof(self, M: int | bytearray) -> bool:
         if isinstance(M, bytearray):

--- a/aiohomekit/crypto/srp.py
+++ b/aiohomekit/crypto/srp.py
@@ -111,8 +111,7 @@ class Srp:
 
     def get_session_key(self) -> int:
         """Return the K value for the session key."""
-        S_b = Srp.to_byte_array(self.get_shared_secret())
-        assert len(S_b) == HK_KEY_LENGTH
+        S_b = pad_left(Srp.to_byte_array(self.get_shared_secret()), HK_KEY_LENGTH)
         return int.from_bytes(self.digest(S_b), "big")
 
     @staticmethod

--- a/aiohomekit/protocol/__init__.py
+++ b/aiohomekit/protocol/__init__.py
@@ -193,8 +193,8 @@ def perform_pair_setup_part2(
     """
 
     srp_client = SrpClient("Pair-Setup", pin)
-    srp_client.set_salt(salt)
-    srp_client.set_server_public_key(server_public_key)
+    srp_client.set_salt_bytes(salt)
+    srp_client.set_server_public_key_bytes(server_public_key)
     client_pub_key_bytes = srp_client.get_public_key_bytes()
     client_proof_bytes = srp_client.get_proof_bytes()
 

--- a/aiohomekit/protocol/__init__.py
+++ b/aiohomekit/protocol/__init__.py
@@ -193,15 +193,15 @@ def perform_pair_setup_part2(
     """
 
     srp_client = SrpClient("Pair-Setup", pin)
-    srp_client.set_salt_bytes(salt)
-    srp_client.set_server_public_key_bytes(server_public_key)
-    client_pub_key_bytes = srp_client.get_public_key_bytes()
-    client_proof_bytes = srp_client.get_proof_bytes()
+    srp_client.set_salt(salt)
+    srp_client.set_server_public_key(server_public_key)
+    client_pub_key = srp_client.get_public_key()
+    client_proof = srp_client.get_proof()
 
     response_tlv = [
         (TLV.kTLVType_State, TLV.M3),
-        (TLV.kTLVType_PublicKey, client_pub_key_bytes),
-        (TLV.kTLVType_Proof, client_proof_bytes),
+        (TLV.kTLVType_PublicKey, SrpClient.to_byte_array(client_pub_key)),
+        (TLV.kTLVType_Proof, SrpClient.to_byte_array(client_proof)),
     ]
 
     step4_expectations = [
@@ -228,7 +228,7 @@ def perform_pair_setup_part2(
         raise AuthenticationError("Step #5: wrong proof!")
 
     # M5 Request generation (page 44)
-    session_key_bytes = srp_client.get_session_key_bytes()
+    session_key = srp_client.get_session_key()
 
     ios_device_ltsk = ed25519.Ed25519PrivateKey.generate()
     ios_device_ltpk = ios_device_ltsk.public_key()
@@ -240,13 +240,13 @@ def perform_pair_setup_part2(
     #   Pair-Setup-Encrypt-Salt instead of Pair-Setup-Controller-Sign-Salt
     #   Pair-Setup-Encrypt-Info instead of Pair-Setup-Controller-Sign-Info
     ios_device_x = hkdf_derive(
-        session_key_bytes,
+        SrpClient.to_byte_array(session_key),
         b"Pair-Setup-Controller-Sign-Salt",
         b"Pair-Setup-Controller-Sign-Info",
     )
 
     session_key = hkdf_derive(
-        session_key_bytes,
+        SrpClient.to_byte_array(session_key),
         b"Pair-Setup-Encrypt-Salt",
         b"Pair-Setup-Encrypt-Info",
     )
@@ -320,7 +320,7 @@ def perform_pair_setup_part2(
     accessory_sig = response_tlv[TLV.kTLVType_Signature]
 
     accessory_x = hkdf_derive(
-        srp_client.get_session_key_bytes(),
+        SrpClient.to_byte_array(srp_client.get_session_key()),
         b"Pair-Setup-Accessory-Sign-Salt",
         b"Pair-Setup-Accessory-Sign-Info",
     )

--- a/aiohomekit/protocol/__init__.py
+++ b/aiohomekit/protocol/__init__.py
@@ -195,13 +195,13 @@ def perform_pair_setup_part2(
     srp_client = SrpClient("Pair-Setup", pin)
     srp_client.set_salt(salt)
     srp_client.set_server_public_key(server_public_key)
-    client_pub_key = srp_client.get_public_key()
-    client_proof = srp_client.get_proof()
+    client_pub_key = srp_client.get_public_key_bytes()
+    client_proof = srp_client.get_proof_bytes()
 
     response_tlv = [
         (TLV.kTLVType_State, TLV.M3),
-        (TLV.kTLVType_PublicKey, SrpClient.to_byte_array(client_pub_key)),
-        (TLV.kTLVType_Proof, SrpClient.to_byte_array(client_proof)),
+        (TLV.kTLVType_PublicKey, client_pub_key),
+        (TLV.kTLVType_Proof, client_proof),
     ]
 
     step4_expectations = [

--- a/aiohomekit/protocol/__init__.py
+++ b/aiohomekit/protocol/__init__.py
@@ -195,6 +195,10 @@ def perform_pair_setup_part2(
     srp_client = SrpClient("Pair-Setup", pin)
     srp_client.set_salt(salt)
     srp_client.set_server_public_key(server_public_key)
+    # We avoid getting the values as ints to ensure
+    # we do not have a conversion issue where the values
+    # have a leading zero and the resulting bytes are too
+    # short to be valid.
     client_pub_key = srp_client.get_public_key_bytes()
     client_proof = srp_client.get_proof_bytes()
 

--- a/aiohomekit/protocol/__init__.py
+++ b/aiohomekit/protocol/__init__.py
@@ -200,8 +200,8 @@ def perform_pair_setup_part2(
 
     response_tlv = [
         (TLV.kTLVType_State, TLV.M3),
-        (TLV.kTLVType_PublicKey, client_pub_key),
-        (TLV.kTLVType_Proof, client_proof),
+        (TLV.kTLVType_PublicKey, client_pub_key_bytes),
+        (TLV.kTLVType_Proof, client_proof_bytes),
     ]
 
     step4_expectations = [

--- a/tests/accessoryserver.py
+++ b/tests/accessoryserver.py
@@ -1350,7 +1350,7 @@ class AccessoryRequestHandler(BaseHTTPRequestHandler):
             self.log_message("Step #4 /pair-setup")
 
             # 1) use ios pub key to compute shared secret key
-            ios_pub_key = int.from_bytes(d_req[1][1], "big")
+            ios_pub_key = d_req[1][1]
             server = self.server.sessions[self.session_id]["srp"]
             server.set_client_public_key(ios_pub_key)
 
@@ -1362,7 +1362,7 @@ class AccessoryRequestHandler(BaseHTTPRequestHandler):
             self.server.sessions[self.session_id]["session_key"] = session_key
 
             # 2) verify ios proof
-            ios_proof = int.from_bytes(d_req[2][1], "big")
+            ios_proof = d_req[2][1]
             if not server.verify_clients_proof(ios_proof):
                 d_res.append(
                     (

--- a/tests/accessoryserver.py
+++ b/tests/accessoryserver.py
@@ -1317,7 +1317,7 @@ class AccessoryRequestHandler(BaseHTTPRequestHandler):
             self.log_message(sc_str)
 
             # 9) create public key
-            public_key = server.get_public_key()
+            public_key = server.get_public_key_bytes()
 
             # 10) create response tlv and send response
             d_res.append(
@@ -1329,13 +1329,13 @@ class AccessoryRequestHandler(BaseHTTPRequestHandler):
             d_res.append(
                 (
                     TLV.kTLVType_PublicKey,
-                    SrpServer.to_byte_array(public_key),
+                    public_key,
                 )
             )
             d_res.append(
                 (
                     TLV.kTLVType_Salt,
-                    SrpServer.to_byte_array(salt),
+                    salt,
                 )
             )
             self._send_response_tlv(d_res)
@@ -1355,7 +1355,7 @@ class AccessoryRequestHandler(BaseHTTPRequestHandler):
             server.set_client_public_key(ios_pub_key)
 
             session_key = hkdf_derive(
-                SrpServer.to_byte_array(server.get_session_key()),
+                server.get_session_key_bytes(),
                 b"Pair-Setup-Encrypt-Salt",
                 b"Pair-Setup-Encrypt-Info",
             )
@@ -1446,10 +1446,10 @@ class AccessoryRequestHandler(BaseHTTPRequestHandler):
             # 3) Derive ios_device_x
             shared_secret = self.server.sessions[self.session_id][
                 "srp"
-            ].get_session_key()
+            ].get_session_key_bytes()
 
             ios_device_x = hkdf_derive(
-                SrpServer.to_byte_array(shared_secret),
+                shared_secret,
                 b"Pair-Setup-Controller-Sign-Salt",
                 b"Pair-Setup-Controller-Sign-Info",
             )
@@ -1505,7 +1505,7 @@ class AccessoryRequestHandler(BaseHTTPRequestHandler):
 
             # 2) derive AccessoryX
             accessory_x = hkdf_derive(
-                SrpServer.to_byte_array(shared_secret),
+                shared_secret,
                 b"Pair-Setup-Accessory-Sign-Salt",
                 b"Pair-Setup-Accessory-Sign-Info",
             )

--- a/tests/accessoryserver.py
+++ b/tests/accessoryserver.py
@@ -1301,7 +1301,7 @@ class AccessoryRequestHandler(BaseHTTPRequestHandler):
             server = SrpServer("Pair-Setup", self.server.data.setup_code)
 
             # 6) create salt
-            salt = server.get_salt()
+            salt = server.get_salt_bytes()
 
             # 8) show setup code to user
             sc = self.server.data.setup_code
@@ -1352,7 +1352,7 @@ class AccessoryRequestHandler(BaseHTTPRequestHandler):
             # 1) use ios pub key to compute shared secret key
             ios_pub_key = d_req[1][1]
             server = self.server.sessions[self.session_id]["srp"]
-            server.set_client_public_key(ios_pub_key)
+            server.set_client_public_key_bytes(ios_pub_key)
 
             session_key = hkdf_derive(
                 server.get_session_key_bytes(),

--- a/tests/accessoryserver.py
+++ b/tests/accessoryserver.py
@@ -1384,7 +1384,7 @@ class AccessoryRequestHandler(BaseHTTPRequestHandler):
                 self.log_message("ios proof was verified")
 
             # 3) generate accessory proof
-            accessory_proof = server.get_proof(ios_proof)
+            accessory_proof = server.get_proof_bytes(ios_proof)
 
             # 4) create response tlv
             d_res.append(
@@ -1396,7 +1396,7 @@ class AccessoryRequestHandler(BaseHTTPRequestHandler):
             d_res.append(
                 (
                     TLV.kTLVType_Proof,
-                    SrpServer.to_byte_array(accessory_proof),
+                    accessory_proof,
                 )
             )
 

--- a/tests/test_crypto_srp.py
+++ b/tests/test_crypto_srp.py
@@ -31,7 +31,7 @@ def test_1(cls):
     setup_code = "123-45-678"  # transmitted on second channel
     server = cls("Pair-Setup", setup_code)
     server_pub_key = server.get_public_key_bytes()
-    server_salt = server.get_salt()
+    server_salt = server.get_salt_bytes()
 
     # step M3
     client = SrpClient("Pair-Setup", setup_code)
@@ -42,7 +42,7 @@ def test_1(cls):
     clients_proof = client.get_proof_bytes()
 
     # step M4
-    server.set_client_public_key(client_pub_key)
+    server.set_client_public_key_bytes(client_pub_key)
     server.get_shared_secret()
     assert server.verify_clients_proof(clients_proof) is True
     servers_proof = server.get_proof_bytes(clients_proof)

--- a/tests/test_crypto_srp.py
+++ b/tests/test_crypto_srp.py
@@ -39,13 +39,13 @@ def test_1(cls):
     client.set_server_public_key(server_pub_key)
 
     client_pub_key = client.get_public_key_bytes()
-    clients_proof = client.get_proof()
+    clients_proof = client.get_proof_bytes()
 
     # step M4
     server.set_client_public_key(client_pub_key)
     server.get_shared_secret()
     assert server.verify_clients_proof(clients_proof) is True
-    servers_proof = server.get_proof(clients_proof)
+    servers_proof = server.get_proof_bytes(clients_proof)
 
     # step M5
     assert client.verify_servers_proof(servers_proof) is True

--- a/tests/test_crypto_srp.py
+++ b/tests/test_crypto_srp.py
@@ -23,18 +23,37 @@ class ZeroSaltSrpServer(SrpServer):
         return b"\x00" * 16
 
 
-@pytest.mark.parametrize("cls", [ZeroSaltSrpServer, SrpServer])
-def test_1(cls):
+class LeadingZeroPrivateKeySrpClient(SrpClient):
+    def generate_private_key(self):
+        return 292137137271783308929690144371568755687
+
+
+class LeadingZeroPrivateAndPublicKeySrpClient(SrpClient):
+    def generate_private_key(self):
+        return 70997313118674976963008287637113704817
+
+
+@pytest.mark.parametrize(
+    "server_cls, client_cls",
+    [
+        (SrpServer, SrpClient),
+        (ZeroSaltSrpServer, SrpClient),
+        (SrpServer, LeadingZeroPrivateKeySrpClient),
+        (SrpServer, LeadingZeroPrivateAndPublicKeySrpClient),
+        (ZeroSaltSrpServer, LeadingZeroPrivateAndPublicKeySrpClient),
+    ],
+)
+def test_1(server_cls, client_cls):
     # step M1
 
     # step M2
     setup_code = "123-45-678"  # transmitted on second channel
-    server = cls("Pair-Setup", setup_code)
+    server: SrpServer = server_cls("Pair-Setup", setup_code)
     server_pub_key = server.get_public_key_bytes()
     server_salt = server.get_salt()
 
     # step M3
-    client = SrpClient("Pair-Setup", setup_code)
+    client: SrpClient = client_cls("Pair-Setup", setup_code)
     client.set_salt(server_salt)
     client.set_server_public_key(server_pub_key)
 

--- a/tests/test_crypto_srp.py
+++ b/tests/test_crypto_srp.py
@@ -31,21 +31,21 @@ def test_1(cls):
     setup_code = "123-45-678"  # transmitted on second channel
     server = cls("Pair-Setup", setup_code)
     server_pub_key = server.get_public_key_bytes()
-    server_salt = server.get_salt_bytes()
+    server_salt = server.get_salt()
 
     # step M3
     client = SrpClient("Pair-Setup", setup_code)
-    client.set_salt_bytes(server_salt)
-    client.set_server_public_key_bytes(server_pub_key)
+    client.set_salt(server_salt)
+    client.set_server_public_key(server_pub_key)
 
     client_pub_key = client.get_public_key_bytes()
-    clients_proof = client.get_proof_bytes()
+    clients_proof = client.get_proof()
 
     # step M4
-    server.set_client_public_key_bytes(client_pub_key)
+    server.set_client_public_key(client_pub_key)
     server.get_shared_secret()
     assert server.verify_clients_proof(clients_proof) is True
-    servers_proof = server.get_proof_bytes(clients_proof)
+    servers_proof = server.get_proof(clients_proof)
 
     # step M5
     assert client.verify_servers_proof(servers_proof) is True

--- a/tests/test_crypto_srp.py
+++ b/tests/test_crypto_srp.py
@@ -24,6 +24,7 @@ from aiohomekit.crypto.srp import SrpClient, SrpServer
 #    if len(pub_key_bytes) < 384:
 #        pprint.pprint(["found key", srp.a])
 
+
 class ZeroSaltSrpServer(SrpServer):
     def _create_salt(self):
         return b"\x00" * 16

--- a/tests/test_crypto_srp.py
+++ b/tests/test_crypto_srp.py
@@ -17,6 +17,12 @@ import pytest
 
 from aiohomekit.crypto.srp import SrpClient, SrpServer
 
+# To find short keys
+# for _ in range(500000):
+#    srp = SrpClient("Pair-Setup", "123-45-789")
+#    pub_key_bytes = SrpClient.to_byte_array(srp.A)
+#    if len(pub_key_bytes) < 384:
+#        pprint.pprint(["found key", srp.a])
 
 class ZeroSaltSrpServer(SrpServer):
     def _create_salt(self):

--- a/tests/test_crypto_srp.py
+++ b/tests/test_crypto_srp.py
@@ -80,15 +80,15 @@ def test_1(server_cls, client_cls):
     client.set_server_public_key(server_pub_key)
 
     client_pub_key = client.get_public_key_bytes()
-    clients_proof = client.get_proof()
+    clients_proof_bytes = client.get_proof_bytes()
 
     # step M4
     server.set_client_public_key(client_pub_key)
     server.get_shared_secret()
-    assert server.verify_clients_proof(clients_proof) is True
-    servers_proof = server.get_proof(clients_proof)
+    assert server.verify_clients_proof_bytes(clients_proof_bytes) is True
+    servers_proof = server.get_proof_bytes(clients_proof_bytes)
 
     # step M5
     assert (
-        client.verify_servers_proof(servers_proof) is True
+        client.verify_servers_proof_bytes(servers_proof) is True
     ), f"proof mismatch: server_key:{server.b} client_key:{client.a} server_salt:{server.salt}"

--- a/tests/test_crypto_srp.py
+++ b/tests/test_crypto_srp.py
@@ -30,7 +30,7 @@ def test_1(cls):
     # step M2
     setup_code = "123-45-678"  # transmitted on second channel
     server = cls("Pair-Setup", setup_code)
-    server_pub_key = server.get_public_key()
+    server_pub_key = server.get_public_key_bytes()
     server_salt = server.get_salt()
 
     # step M3
@@ -38,7 +38,7 @@ def test_1(cls):
     client.set_salt(server_salt)
     client.set_server_public_key(server_pub_key)
 
-    client_pub_key = client.get_public_key()
+    client_pub_key = client.get_public_key_bytes()
     clients_proof = client.get_proof()
 
     # step M4

--- a/tests/test_crypto_srp.py
+++ b/tests/test_crypto_srp.py
@@ -13,16 +13,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import pytest
 
-from aiohomekit.crypto.srp import SrpClient, SrpServer
+from aiohomekit.crypto.srp import SrpClient, SrpServer, pad_left, to_byte_array
 
 
-def test_1():
+class ZeroSaltSrpServer(SrpServer):
+    def _create_salt(self):
+        return b"\x00" * 16
+
+
+@pytest.mark.parametrize("cls", [ZeroSaltSrpServer, SrpServer])
+def test_1(cls):
     # step M1
 
     # step M2
     setup_code = "123-45-678"  # transmitted on second channel
-    server = SrpServer("Pair-Setup", setup_code)
+    server = cls("Pair-Setup", setup_code)
     server_pub_key = server.get_public_key()
     server_salt = server.get_salt()
 

--- a/tests/test_crypto_srp.py
+++ b/tests/test_crypto_srp.py
@@ -35,8 +35,8 @@ def test_1(cls):
 
     # step M3
     client = SrpClient("Pair-Setup", setup_code)
-    client.set_salt(server_salt)
-    client.set_server_public_key(server_pub_key)
+    client.set_salt_bytes(server_salt)
+    client.set_server_public_key_bytes(server_pub_key)
 
     client_pub_key = client.get_public_key_bytes()
     clients_proof = client.get_proof_bytes()

--- a/tests/test_crypto_srp.py
+++ b/tests/test_crypto_srp.py
@@ -40,6 +40,16 @@ class LeadingZeroPrivateAndPublicKeySrpClient(SrpClient):
         return 70997313118674976963008287637113704817
 
 
+class LeadingZeroPrivateKeySrpServer(SrpServer):
+    def generate_private_key(self):
+        return 292137137271783308929690144371568755687
+
+
+class LeadingZeroPrivateAndPublicKeySrpServer(SrpServer):
+    def generate_private_key(self):
+        return 70997313118674976963008287637113704817
+
+
 @pytest.mark.parametrize(
     "server_cls, client_cls",
     [
@@ -48,6 +58,11 @@ class LeadingZeroPrivateAndPublicKeySrpClient(SrpClient):
         (SrpServer, LeadingZeroPrivateKeySrpClient),
         (SrpServer, LeadingZeroPrivateAndPublicKeySrpClient),
         (ZeroSaltSrpServer, LeadingZeroPrivateAndPublicKeySrpClient),
+        (
+            LeadingZeroPrivateAndPublicKeySrpServer,
+            LeadingZeroPrivateAndPublicKeySrpClient,
+        ),
+        (LeadingZeroPrivateKeySrpServer, LeadingZeroPrivateAndPublicKeySrpClient),
     ],
 )
 def test_1(server_cls, client_cls):

--- a/tests/test_crypto_srp.py
+++ b/tests/test_crypto_srp.py
@@ -26,7 +26,7 @@ from aiohomekit.crypto.srp import SrpClient, SrpServer
 
 
 class ZeroSaltSrpServer(SrpServer):
-    def _create_salt(self):
+    def _create_salt_bytes(self):
         return b"\x00" * 16
 
 
@@ -89,4 +89,6 @@ def test_1(server_cls, client_cls):
     servers_proof = server.get_proof(clients_proof)
 
     # step M5
-    assert client.verify_servers_proof(servers_proof) is True
+    assert (
+        client.verify_servers_proof(servers_proof) is True
+    ), f"proof mismatch: server_key:{server.b} client_key:{client.a} server_salt:{server.salt}"

--- a/tests/test_crypto_srp.py
+++ b/tests/test_crypto_srp.py
@@ -15,7 +15,7 @@
 #
 import pytest
 
-from aiohomekit.crypto.srp import SrpClient, SrpServer, pad_left, to_byte_array
+from aiohomekit.crypto.srp import SrpClient, SrpServer
 
 
 class ZeroSaltSrpServer(SrpServer):


### PR DESCRIPTION
Allows LIFX beam to pair

Refactoring to reduce int to bytes conversion to avoid the risk of random pairing failures when there are leading zeros in the key or salt since they would end up converted to short bytearrays

<img width="1018" alt="Screen Shot 2022-08-12 at 9 06 14 PM" src="https://user-images.githubusercontent.com/663432/184473017-9b3f533d-23ff-42d0-875f-dc5ff22f50c8.png">

