### PR TITLE
Fix CoAP pairing

### DIFF
--- a/aiohomekit/controller/coap/connection.py
+++ b/aiohomekit/controller/coap/connection.py
@@ -625,7 +625,7 @@ class CoAPHomeKitConnection:
         return results
 
     async def unsubscribe_from(self, ids: list[tuple[int, int]]):
-        if len(ids) == 0:
+        if not ids:
             return {}
         iids = [int(aid_iid[1]) for aid_iid in ids]
         data = [b""] * len(iids)

--- a/aiohomekit/controller/coap/connection.py
+++ b/aiohomekit/controller/coap/connection.py
@@ -625,6 +625,8 @@ class CoAPHomeKitConnection:
         return results
 
     async def unsubscribe_from(self, ids: list[tuple[int, int]]):
+        if len(ids) == 0:
+            return {}
         iids = [int(aid_iid[1]) for aid_iid in ids]
         data = [b""] * len(iids)
         pdu_results = await self.enc_ctx.post_all(OpCode.UNK_0C_UNSUBSCRIBE, iids, data)


### PR DESCRIPTION
A splat occurs during pair-setup when we attempt to unsubscribe from nothing.