### PR TITLE
Fix ble device not being passed from discovery to pairing when paired

### DIFF
--- a/aiohomekit/controller/ble/manufacturer_data.py
+++ b/aiohomekit/controller/ble/manufacturer_data.py
@@ -3,11 +3,12 @@ from __future__ import annotations
 from dataclasses import dataclass
 import struct
 
+from bleak.backends.device import BLEDevice
+from bleak.backends.scanner import AdvertisementData
+
 from aiohomekit.controller.abstract import AbstractDescription
 from aiohomekit.model.categories import Categories
 from aiohomekit.model.status_flags import StatusFlags
-from bleak.backends.device import BLEDevice
-from bleak.backends.scanner import AdvertisementData
 
 
 @dataclass

--- a/aiohomekit/controller/ble/manufacturer_data.py
+++ b/aiohomekit/controller/ble/manufacturer_data.py
@@ -6,6 +6,8 @@ import struct
 from aiohomekit.controller.abstract import AbstractDescription
 from aiohomekit.model.categories import Categories
 from aiohomekit.model.status_flags import StatusFlags
+from bleak.backends.device import BLEDevice
+from bleak.backends.scanner import AdvertisementData
 
 
 @dataclass
@@ -44,7 +46,9 @@ class HomeKitAdvertisement(AbstractDescription):
         )
 
     @classmethod
-    def from_advertisement(cls, device, advertisement_data) -> HomeKitAdvertisement:
+    def from_advertisement(
+        cls, device: BLEDevice, advertisement_data: AdvertisementData
+    ) -> HomeKitAdvertisement:
         if not (mfr_data := advertisement_data.manufacturer_data):
             raise ValueError("No manufacturer data")
 


### PR DESCRIPTION
We pass the connection on to the pairing once we finish pairing, however if the device is on the edge of range and it disconnects before the next ADV is received, device is unset and we cannot reconnect.

Also log the RSSI so we get a better idea why pairing is failing.
