### PR TITLE
Get rid of reconnect_soon

### DIFF
--- a/aiohomekit/controller/abstract.py
+++ b/aiohomekit/controller/abstract.py
@@ -228,13 +228,6 @@ class AbstractPairing(metaclass=ABCMeta):
     async def unsubscribe(self, characteristics: Iterable[tuple[int, int]]) -> None:
         self.subscriptions.difference_update(characteristics)
 
-    async def reconnect_soon(self) -> None:
-        """
-        Notify the pairing that we have noticed a network change that means its connection maybe stale.
-
-        This will be removed in a future release.
-        """
-
     def dispatcher_availability_changed(
         self, callback: Callable[[bool], None]
     ) -> Callable[[], None]:

--- a/aiohomekit/controller/ip/connection.py
+++ b/aiohomekit/controller/ip/connection.py
@@ -241,7 +241,7 @@ class HomeKitConnection:
         self._connector = async_create_task(self._reconnect())
         self._connector.add_done_callback(done_callback)
 
-    async def reconnect_soon(self) -> None:
+    def reconnect_soon(self) -> None:
         """Reconnect to the device if disconnected.
 
         If a reconnect is in progress, the reconnection wait is canceled

--- a/aiohomekit/zeroconf.py
+++ b/aiohomekit/zeroconf.py
@@ -276,13 +276,21 @@ class ZeroconfController(AbstractController):
             logger.debug("%s: Not a valid homekit device: %s", info.name, e)
             return
 
-        if description.id in self.discoveries:
-            self.discoveries[description.id]._update_from_discovery(description)
-            return
+        if discovery := self.discoveries.get(description.id):
+            discovery._update_from_discovery(description)
+        else:
+            discovery = self.discoveries[description.id] = self._make_discovery(
+                description
+            )
 
         discovery = self.discoveries[description.id] = self._make_discovery(description)
 
         if pairing := self.pairings.get(description.id):
+            logger.debug(
+                "%s: Notifying pairing of description update: %s",
+                description.id,
+                description,
+            )
             pairing._async_description_update(description)
 
         if waiters := self._waiters.pop(description.id, None):

--- a/aiohomekit/zeroconf.py
+++ b/aiohomekit/zeroconf.py
@@ -151,7 +151,7 @@ class ZeroconfPairing(AbstractPairing):
         if not old_description:
             logger.debug("%s: Device rediscovered", self.id)
             endpoint_changed = True
-        elif old_description.port != description.port:
+        elif old_description.address != description.address:
             logger.debug(
                 "%s: Device IP changed from %s to %s",
                 self.id,
@@ -159,7 +159,7 @@ class ZeroconfPairing(AbstractPairing):
                 description.address,
             )
             endpoint_changed = True
-        elif old_description.address != description.address:
+        elif old_description.port != description.port:
             logger.debug(
                 "%s: Device port changed from %s to %s",
                 self.id,

--- a/tests/test_ip_pairing.py
+++ b/tests/test_ip_pairing.py
@@ -63,9 +63,9 @@ async def test_reconnect_soon_after_disconnected(pairing: IpPairing):
     assert not pairing.is_available
 
     # Ensure we can safely call multiple times
-    await pairing.reconnect_soon()
-    await pairing.reconnect_soon()
-    await pairing.reconnect_soon()
+    pairing._async_description_update(None)
+    pairing._async_description_update(None)
+    pairing._async_description_update(None)
 
     await asyncio.wait_for(pairing.connection._connector, timeout=0.5)
     assert pairing.connection.is_connected
@@ -93,14 +93,14 @@ async def test_reconnect_soon_after_device_is_offline_for_a_bit(pairing: IpPairi
         assert not pairing.is_available
 
         for _ in range(3):
-            await pairing.reconnect_soon()
+            pairing._async_description_update(None)
             with pytest.raises(asyncio.TimeoutError):
                 await asyncio.wait_for(
                     asyncio.shield(pairing.connection._connector), timeout=0.2
                 )
             assert not pairing.connection.is_connected
 
-    await pairing.reconnect_soon()
+    pairing._async_description_update(None)
     await asyncio.wait_for(pairing.connection._connector, timeout=0.5)
     assert pairing.connection.is_connected
     assert pairing.is_available


### PR DESCRIPTION
This was something I wanted to do with the introduction of BLE into HA, as it was a transport specific concept. With the changes in #151 we can now fully do it.

This has no impact for BLE, which never used it. It has no impact for CoAP, which stopped using it in #151. The only impact for IP is that the "service info changed" signal now comes directly from zeroconf (via `_async_description_updated`) instead of via the config flow code in home assistant.

I also pulled the logic for detecting an ip/address change out of CoAP, as it applies to both IP based backends.

I could temporarily revert the changes to aiohomekit/controller/abstract.py to make it easier to test.