### PR TITLE
Handle zeroconf c# changes directly not via notify_config_changed

### DIFF
--- a/aiohomekit/controller/abstract.py
+++ b/aiohomekit/controller/abstract.py
@@ -117,8 +117,9 @@ class AbstractPairing(metaclass=ABCMeta):
     def poll_interval(self) -> timedelta:
         """Returns how often the device should be polled."""
 
+    @abstractmethod
     async def _process_disconnected_events(self):
-        pass
+        """Process any disconnected events that are available."""
 
     def _async_description_update(
         self, description: AbstractDescription | None

--- a/aiohomekit/controller/abstract.py
+++ b/aiohomekit/controller/abstract.py
@@ -121,7 +121,7 @@ class AbstractPairing(metaclass=ABCMeta):
         if self.description != description:
             logger.debug(
                 "%s: Description updated: old=%s new=%s",
-                self.name,
+                self.id,
                 self.description,
                 description,
             )
@@ -131,7 +131,7 @@ class AbstractPairing(metaclass=ABCMeta):
             if description.config_num > self.description.config_num:
                 logger.debug(
                     "%s: Config number has changed from %s to %s; char cache invalid",
-                    self.name,
+                    self.id,
                     self.description.config_num,
                     description.config_num,
                 )
@@ -150,7 +150,7 @@ class AbstractPairing(metaclass=ABCMeta):
                 # as we don't want to miss events.
                 logger.debug(
                     "%s: Disconnected event notification received; Triggering catch-up poll",
-                    self.name,
+                    self.id,
                 )
                 async_create_task(self._process_disconnected_events())
 

--- a/aiohomekit/controller/abstract.py
+++ b/aiohomekit/controller/abstract.py
@@ -98,6 +98,13 @@ class AbstractPairing(metaclass=ABCMeta):
         return self._accessories_state.config_num
 
     @property
+    def name(self) -> str:
+        """Return the name of the pairing."""
+        if self.description:
+            return f"{self.description.name} (id={self.id})"
+        return f"(id={self.id})"
+
+    @property
     @abstractmethod
     def is_connected(self) -> bool:
         """Returns true if the device is currently connected."""
@@ -127,7 +134,7 @@ class AbstractPairing(metaclass=ABCMeta):
         if self.description != description:
             logger.debug(
                 "%s: Description updated: old=%s new=%s",
-                self.id,
+                self.name,
                 self.description,
                 description,
             )
@@ -137,7 +144,7 @@ class AbstractPairing(metaclass=ABCMeta):
             if description.config_num > self.config_num:
                 logger.debug(
                     "%s: Config number has changed from %s to %s; char cache invalid",
-                    self.id,
+                    self.name,
                     self.config_num,
                     description.config_num,
                 )
@@ -159,7 +166,7 @@ class AbstractPairing(metaclass=ABCMeta):
                 # as we don't want to miss events.
                 logger.debug(
                     "%s: Disconnected event notification received; Triggering catch-up poll",
-                    self.id,
+                    self.name,
                 )
                 async_create_task(self._process_disconnected_events())
 

--- a/aiohomekit/controller/abstract.py
+++ b/aiohomekit/controller/abstract.py
@@ -20,6 +20,7 @@ from abc import ABCMeta, abstractmethod
 from collections.abc import AsyncIterable, Awaitable, Iterable
 from dataclasses import dataclass
 from datetime import timedelta
+import logging
 from typing import Any, Callable, TypedDict, final
 
 from aiohomekit.characteristic_cache import CharacteristicCacheType
@@ -29,6 +30,8 @@ from aiohomekit.model.characteristics.characteristic_types import Characteristic
 from aiohomekit.model.services.service_types import ServicesTypes
 from aiohomekit.model.status_flags import StatusFlags
 from aiohomekit.utils import async_create_task
+
+logger = logging.getLogger(__name__)
 
 
 class AbstractPairingData(TypedDict, total=False):
@@ -109,10 +112,52 @@ class AbstractPairing(metaclass=ABCMeta):
     def poll_interval(self) -> timedelta:
         """Returns how often the device should be polled."""
 
+    async def _process_disconnected_events(self):
+        pass
+
     def _async_description_update(
         self, description: AbstractDescription | None
     ) -> None:
+        if self.description != description:
+            logger.debug(
+                "%s: Description updated: old=%s new=%s",
+                self.name,
+                self.description,
+                description,
+            )
+
+        repopulate_accessories = False
+        if description and self.description:
+            if description.config_num > self.description.config_num:
+                logger.debug(
+                    "%s: Config number has changed from %s to %s; char cache invalid",
+                    self.name,
+                    self.description.config_num,
+                    description.config_num,
+                )
+                repopulate_accessories = True
+
+            elif description.state_num != self.description.state_num:
+                # Only process disconnected events if the config number has
+                # not also changed since we will do a full repopulation
+                # of the accessories anyway when the config number changes.
+                #
+                # Otherwise, if only the state number we trigger a poll.
+                #
+                # The number will eventually roll over
+                # so we don't want to use a > comparison here. Also, its
+                # safer to poll the device again to get the latest state
+                # as we don't want to miss events.
+                logger.debug(
+                    "%s: Disconnected event notification received; Triggering catch-up poll",
+                    self.name,
+                )
+                async_create_task(self._process_disconnected_events())
+
         self.description = description
+
+        if repopulate_accessories:
+            async_create_task(self._process_config_changed(description.config_num))
 
     def _load_accessories_from_cache(self) -> None:
         if (cache := self.controller._char_cache.get_map(self.id)) is None:
@@ -212,11 +257,6 @@ class AbstractPairing(metaclass=ABCMeta):
         for callback in self.config_changed_listeners:
             callback(self.config_num)
         self._update_accessories_state_cache()
-
-    def notify_config_changed(self, config_num: int) -> None:
-        """Notify the pairing that the config number has changed."""
-        if config_num != self.config_num:
-            async_create_task(self._process_config_changed(config_num))
 
     async def subscribe(
         self, characteristics: Iterable[tuple[int, int]]

--- a/aiohomekit/controller/abstract.py
+++ b/aiohomekit/controller/abstract.py
@@ -137,7 +137,7 @@ class AbstractPairing(metaclass=ABCMeta):
                 logger.debug(
                     "%s: Config number has changed from %s to %s; char cache invalid",
                     self.id,
-                    self.description.config_num,
+                    self.config_num,
                     description.config_num,
                 )
                 repopulate_accessories = True

--- a/aiohomekit/controller/ble/pairing.py
+++ b/aiohomekit/controller/ble/pairing.py
@@ -121,9 +121,8 @@ class BlePairing(AbstractPairing):
         client: AIOHomeKitBleakClient | None = None,
         description: HomeKitAdvertisement | None = None,
     ) -> None:
-        super().__init__(controller)
+        super().__init__(controller, pairing_data)
 
-        self.id = pairing_data["AccessoryPairingID"]
         self.device = device
         self.client = client
         self._cached_services: BleakGATTServiceCollection | None = (
@@ -552,9 +551,6 @@ class BlePairing(AbstractPairing):
                 # No need to do it twice if we already have the data
                 # and we are not forcing an update
                 return
-
-            if not self.accessories:
-                self._load_accessories_from_cache()
 
             update_values = force_update
             config_changed = False

--- a/aiohomekit/controller/ble/pairing.py
+++ b/aiohomekit/controller/ble/pairing.py
@@ -175,8 +175,8 @@ class BlePairing(AbstractPairing):
     def name(self) -> str:
         """Return the name of the pairing with the address."""
         if self.description:
-            return f"{self.description.name} [address={self.address}] (id={self.id})"
-        return f"[address={self.address}] (id={self.id})"
+            return f"{self.description.name} [{self.address}] (id={self.id})"
+        return f"[{self.address}] (id={self.id})"
 
     @property
     def rssi(self) -> int | None:

--- a/aiohomekit/controller/ble/pairing.py
+++ b/aiohomekit/controller/ble/pairing.py
@@ -238,37 +238,7 @@ class BlePairing(AbstractPairing):
                 description,
             )
 
-        repopulate_accessories = False
-        if description and self.description:
-            if description.config_num > self.description.config_num:
-                logger.debug(
-                    "%s: Config number has changed from %s to %s; char cache invalid",
-                    self.name,
-                    self.description.config_num,
-                    description.config_num,
-                )
-                repopulate_accessories = True
-
-            elif description.state_num != self.description.state_num:
-                # Only process disconnected events if the config number has
-                # not also changed since we will do a full repopulation
-                # of the accessories anyway when the config number changes.
-                #
-                # Otherwise, if only the state number we trigger a poll.
-                #
-                # The number will eventually roll over
-                # so we don't want to use a > comparison here. Also, its
-                # safer to poll the device again to get the latest state
-                # as we don't want to miss events.
-                logger.debug(
-                    "%s: Disconnected event notification received; Triggering catch-up poll",
-                    self.name,
-                )
-                async_create_task(self._async_process_disconnected_events())
-
         super()._async_description_update(description)
-        if repopulate_accessories:
-            async_create_task(self._async_process_config_changed())
 
     async def _async_request(
         self, opcode: OpCode, char: Characteristic, data: bytes | None = None
@@ -405,17 +375,6 @@ class BlePairing(AbstractPairing):
             # Used for session resume
             self._session_id = session_id
             self._derive = derive
-
-    async def _async_process_config_changed(self) -> None:
-        """Handle config changed seen from the advertisement."""
-        try:
-            await self._populate_accessories_and_characteristics()
-        except (
-            AccessoryDisconnectedError,
-            *BLEAK_EXCEPTIONS,
-            AccessoryNotFoundError,
-        ) as exc:
-            logger.warning("%s: Failed to process config change: %s", self.name, exc)
 
     async def _async_process_disconnected_events(self) -> None:
         """Handle disconnected events seen from the advertisement."""

--- a/aiohomekit/controller/ble/pairing.py
+++ b/aiohomekit/controller/ble/pairing.py
@@ -375,7 +375,7 @@ class BlePairing(AbstractPairing):
             self._session_id = session_id
             self._derive = derive
 
-    async def _async_process_disconnected_events(self) -> None:
+    async def _process_disconnected_events(self) -> None:
         """Handle disconnected events seen from the advertisement."""
         logger.debug(
             "%s: Polling subscriptions for changes during disconnection; rssi=%s",

--- a/aiohomekit/controller/ble/pairing.py
+++ b/aiohomekit/controller/ble/pairing.py
@@ -173,10 +173,10 @@ class BlePairing(AbstractPairing):
 
     @property
     def name(self) -> str:
-        """Return the name of the pairing."""
+        """Return the name of the pairing with the address."""
         if self.description:
-            return f"{self.description.name} ({self.address})"
-        return self.address
+            return f"{self.description.name} [address={self.address}] (id={self.id})"
+        return f"[address={self.address}] (id={self.id})"
 
     @property
     def rssi(self) -> int | None:

--- a/aiohomekit/controller/coap/pairing.py
+++ b/aiohomekit/controller/coap/pairing.py
@@ -35,9 +35,7 @@ class CoAPPairing(ZeroconfPairing):
     def __init__(
         self, controller: AbstractController, pairing_data: AbstractPairingData
     ) -> None:
-        super().__init__(controller)
-
-        self.id = pairing_data["AccessoryPairingID"]
+        super().__init__(controller, pairing_data)
 
         self.connection = CoAPHomeKitConnection(
             self, pairing_data["AccessoryIP"], pairing_data["AccessoryPort"]

--- a/aiohomekit/controller/coap/pairing.py
+++ b/aiohomekit/controller/coap/pairing.py
@@ -63,6 +63,13 @@ class CoAPPairing(ZeroconfPairing):
         return Transport.COAP
 
     @property
+    def name(self) -> str:
+        """Return the name of the pairing with the address."""
+        if self.description:
+            return f"{self.description.name} [{self.connection.address}] (id={self.id})"
+        return f"[{self.connection.address}] (id={self.id})"
+
+    @property
     def poll_interval(self) -> timedelta:
         """Returns how often the device should be polled."""
         return timedelta(minutes=1)

--- a/aiohomekit/controller/coap/pairing.py
+++ b/aiohomekit/controller/coap/pairing.py
@@ -150,6 +150,7 @@ class CoAPPairing(ZeroconfPairing):
         self._accessories_state = AccessoriesState(
             Accessories.from_list(accessories), self.config_num or 0
         )
+        self._update_accessories_state_cache()
         return accessories
 
     async def _process_config_changed(self, config_num: int) -> None:

--- a/aiohomekit/controller/coap/pairing.py
+++ b/aiohomekit/controller/coap/pairing.py
@@ -164,6 +164,12 @@ class CoAPPairing(ZeroconfPairing):
         )
         self._callback_and_save_config_changed(config_num)
 
+    async def _process_disconnected_events(self):
+        """Process any events that happened while we were disconnected.
+
+        We don't disconnect in COAP so there is no need to do anything here.
+        """
+
     async def async_populate_accessories_state(
         self, force_update: bool = False
     ) -> bool:

--- a/aiohomekit/controller/ip/pairing.py
+++ b/aiohomekit/controller/ip/pairing.py
@@ -168,6 +168,7 @@ class IpPairing(ZeroconfPairing):
         self._accessories_state = AccessoriesState(
             Accessories.from_list(accessories), self.config_num or 0
         )
+        self._update_accessories_state_cache()
         return accessories
 
     async def list_pairings(self):

--- a/aiohomekit/controller/ip/pairing.py
+++ b/aiohomekit/controller/ip/pairing.py
@@ -106,8 +106,8 @@ class IpPairing(ZeroconfPairing):
     def name(self) -> str:
         """Return the name of the pairing with the address."""
         if self.description:
-            return f"{self.description.name} [address={self.connection.host}:{self.connection.port}] (id={self.id})"
-        return f"[address={self.connection.host}:{self.connection.port}] (id={self.id})"
+            return f"{self.description.name} [{self.connection.host}:{self.connection.port}] (id={self.id})"
+        return f"[{self.connection.host}:{self.connection.port}] (id={self.id})"
 
     def event_received(self, event):
         self._callback_listeners(format_characteristic_list(event))

--- a/aiohomekit/controller/ip/pairing.py
+++ b/aiohomekit/controller/ip/pairing.py
@@ -102,6 +102,13 @@ class IpPairing(ZeroconfPairing):
         """Returns how often the device should be polled."""
         return timedelta(minutes=1)
 
+    @property
+    def name(self) -> str:
+        """Return the name of the pairing with the address."""
+        if self.description:
+            return f"{self.description.name} [address={self.connection.host}:{self.connection.port}] (id={self.id})"
+        return f"[address={self.connection.host}:{self.connection.port}] (id={self.id})"
+
     def event_received(self, event):
         self._callback_listeners(format_characteristic_list(event))
 

--- a/aiohomekit/controller/ip/pairing.py
+++ b/aiohomekit/controller/ip/pairing.py
@@ -78,8 +78,7 @@ class IpPairing(ZeroconfPairing):
 
         :param pairing_data:
         """
-        super().__init__(controller)
-        self.id = pairing_data["AccessoryPairingID"]
+        super().__init__(controller, pairing_data)
         self.pairing_data = pairing_data
         self.connection = SecureHomeKitConnection(self, self.pairing_data)
         self.supports_subscribe = True

--- a/aiohomekit/controller/ip/pairing.py
+++ b/aiohomekit/controller/ip/pairing.py
@@ -380,6 +380,12 @@ class IpPairing(ZeroconfPairing):
         )
         self._callback_and_save_config_changed(self.config_num)
 
+    async def _process_disconnected_events(self):
+        """Process any events that happened while we were disconnected.
+
+        We don't disconnect in IP so there is no need to do anything here.
+        """
+
     async def identify(self):
         """
         This call can be used to trigger the identification of a paired accessory. A successful call should

--- a/aiohomekit/testing.py
+++ b/aiohomekit/testing.py
@@ -271,6 +271,9 @@ class FakePairing(AbstractPairing):
         )
         self._callback_and_save_config_changed(config_num)
 
+    async def _process_disconnected_events(self):
+        """Process any events that happened while we were disconnected."""
+
     async def list_accessories_and_characteristics(self):
         """Fake implementation of list_accessories_and_characteristics."""
         self._ensure_connected()

--- a/aiohomekit/testing.py
+++ b/aiohomekit/testing.py
@@ -204,9 +204,7 @@ class FakePairing(AbstractPairing):
         accessories: Accessories,
     ) -> None:
         """Create a fake pairing from an accessory model."""
-        super().__init__(controller)
-
-        self.id = pairing_data["AccessoryPairingID"]
+        super().__init__(controller, pairing_data)
 
         self._accessories_state = AccessoriesState(accessories, 0)
         self.pairing_data: dict[str, str] = {}


### PR DESCRIPTION
Gets rid of `notify_config_changed` entirely, prefering to do it internally based on triggers from zeroconf.

Note that BLE had `_process_config_changed` and `_async_process_config_changed`. One was trigger by bluetooth advertisements, one was triggered by HA. I have removed an arbritary one.

The thing I'm not yet decided on how to handle is state_num. It's important that its nestled in with the c# checks as that optimises the case where both have changed. But its a waste to create a task on IP and CoAP as they don't sue state_num. Could make it a sync callback, and only create a task in the BLE backend?