### PR TITLE
Bump bleak-retry-connector to implement a smart backoff 

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -777,7 +777,7 @@ ifaddr = ">=0.1.7"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "daf82b51c6b5ad3ab2229e601f4f4d87e4c67832818745df48e5f3c21198536c"
+content-hash = "a96a9bfedc9985dfa0761888926d8aa3d96eb0d4638200d42a3e69178cb015cc"
 
 [metadata.files]
 aiocoap = [

--- a/poetry.lock
+++ b/poetry.lock
@@ -138,7 +138,7 @@ typing-extensions = ">=4.2.0"
 
 [[package]]
 name = "bleak-retry-connector"
-version = "1.13.0"
+version = "1.14.0"
 description = "A connector for Bleak Clients that handles transient connection failures"
 category = "main"
 optional = false
@@ -777,7 +777,7 @@ ifaddr = ">=0.1.7"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "8f684f2680dfb04969168c9bf549a8ee66cd77a08fcf762b82d0ab47a4e41410"
+content-hash = "daf82b51c6b5ad3ab2229e601f4f4d87e4c67832818745df48e5f3c21198536c"
 
 [metadata.files]
 aiocoap = [
@@ -911,8 +911,8 @@ bleak = [
     {file = "bleak-0.15.1.tar.gz", hash = "sha256:d8c8d88de0f22a15bd135ba056c4e5b2fb9f15119283def21b1ed7d43c00d590"},
 ]
 bleak-retry-connector = [
-    {file = "bleak-retry-connector-1.13.0.tar.gz", hash = "sha256:6b4280952eea6dcf5b2be638bcf981f77a26591f25da13e7d65e78b2bdd6bef5"},
-    {file = "bleak_retry_connector-1.13.0-py3-none-any.whl", hash = "sha256:3edde3639d511a462af1c691f90aa2548b0e5eff2f6b6dbea821509e2ee05d55"},
+    {file = "bleak-retry-connector-1.14.0.tar.gz", hash = "sha256:cb0862c0c932b25701fa9828ab2b9eb5e3deb9cf1360033173144a5638470e42"},
+    {file = "bleak_retry_connector-1.14.0-py3-none-any.whl", hash = "sha256:344680fb30d79dcaa2586badd634a5a2f74dbb91ddb621d52ca81373d81dc587"},
 ]
 bleak-winrt = [
     {file = "bleak-winrt-1.1.1.tar.gz", hash = "sha256:3e7765f98d71b5229d95bd3b197931994dead40f3144e7186de7b8f664e26df0"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ commentjson = "^0.9.0"
 aiocoap = ">=0.4.1"
 bleak = ">=0.14.2"
 chacha20poly1305-reuseable = ">=0.0.4"
-bleak-retry-connector = ">=1.13.0"
+bleak-retry-connector = ">=0.14.0"
 orjson = ">=3.7.8"
 async-timeout = "^4.0.2"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ commentjson = "^0.9.0"
 aiocoap = ">=0.4.1"
 bleak = ">=0.14.2"
 chacha20poly1305-reuseable = ">=0.0.4"
-bleak-retry-connector = ">=0.14.0"
+bleak-retry-connector = ">=1.14.0"
 orjson = ">=3.7.8"
 async-timeout = "^4.0.2"
 


### PR DESCRIPTION
When the device is still connected for a few ms after an abort we need to wait for it to fully disconnect