### PR TITLE
Add missing TLV field

### DIFF
--- a/aiohomekit/controller/coap/structs.py
+++ b/aiohomekit/controller/coap/structs.py
@@ -48,6 +48,10 @@ class Pdu09Characteristic(TLVStruct):
         HAP_TLV.kTLVHAPParamHAPValidValuesRangeDescriptor
     )
 
+    user_descriptor: bytes = tlv_entry(
+        HAP_TLV.kTLVHAPParamGATTUserDescriptionDescriptor
+    )
+
     @property
     def supports_read(self) -> bool:
         return self.properties & 0x0001


### PR DESCRIPTION
Eve Energy uses TLV 11. It wasn't in the struct, so parsing exploded. This fixes that.