### PR TITLE
Enable CoAP by default

### DIFF
--- a/aiohomekit/const.py
+++ b/aiohomekit/const.py
@@ -33,9 +33,8 @@ else:
 
 
 try:
-    if "AIOHOMEKIT_TRANSPORT_COAP" in os.environ:
-        __import__("aiocoap")
-        COAP_TRANSPORT_SUPPORTED = True
+    __import__("aiocoap")
+    COAP_TRANSPORT_SUPPORTED = True
 except ModuleNotFoundError:
     pass
 


### PR DESCRIPTION
I think we are inching closer with this, so I thought i'd open up a PR to discuss the next steps.

I currently have an Eve Energy, Eve Thermo and Nanoleaf NL55 working over Thread on HA `main`, with a Homepod running as a border router.

To get all the devices onto thread the basic process I followed was:

* Pair to HomeKit with iOS
* Use Eve app to verify Thread status
* Unpair the device from iOS
* Pair with Home Assistant

For the Energy and Nanoleaf in particular, this was quite painless. And it's very similar to the process we already use when WiFi devices need the WiFi creds provisioning.

Eve Thermo was trickier. It looks like it has a bug where you can't actually unpair it over CoAP (even with iOS). So I had to disable my border routers and wait till I could "Identify" over bluetooth. If you do this right, you can remove the Eve Thermo whilst leaving its Thread provisioning intact. After switching the border router back on, I could pair over CoAP as normal.

CC @roysjosh @bdraco 