### PR TITLE
Passthrough kwargs to BleakClient

### DIFF
--- a/aiohomekit/controller/ble/bleak.py
+++ b/aiohomekit/controller/ble/bleak.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from functools import lru_cache
 import logging
+from typing import Any
 import uuid
 
 from bleak.backends.characteristic import BleakGATTCharacteristic
@@ -69,9 +70,9 @@ def _determine_fragment_size(
 class AIOHomeKitBleakClient(BleakClientWithServiceCache):
     """Wrapper for bleak.BleakClient that auto discovers the max mtu."""
 
-    def __init__(self, address_or_ble_device: BLEDevice | str) -> None:
+    def __init__(self, address_or_ble_device: BLEDevice | str, **kwargs: Any) -> None:
         """Wrap bleak."""
-        super().__init__(address_or_ble_device)
+        super().__init__(address_or_ble_device, **kwargs)
         self._char_cache: dict[tuple[str, str], BleakGATTCharacteristic] = {}
         self._iid_cache: dict[BleakGATTCharacteristic, int] = {}
 


### PR DESCRIPTION
Bleak now wants the disconnected_callback in the constructor so we must pass all the kwargs for future compat

Fixes
```
Sep 26 05:03:12 homeassistant homeassistant[485]: TypeError: AIOHomeKitBleakClient.__init__() got an unexpected keyword argument 'disconnected_callback'
```
unblocks: https://github.com/Bluetooth-Devices/bleak-retry-connector/pull/49