### PR TITLE
fix: skip services that are missing an iid

### DIFF
--- a/aiohomekit/controller/ble/pairing.py
+++ b/aiohomekit/controller/ble/pairing.py
@@ -571,24 +571,27 @@ class BlePairing(AbstractPairing):
         services = await self.client.get_services()
         for service in services:
             ble_service_char = service.get_characteristic(SERVICE_INSTANCE_ID_UUID)
-            service_iid = None
-            if ble_service_char:
-                service_iid_bytes = await self.client.read_gatt_char(
-                    ble_service_char.handle
-                )
-                service_iid = int.from_bytes(service_iid_bytes, "little")
+            if not ble_service_char:
                 logger.debug(
-                    "%s: Service %s iid: %s (decoded as %s)",
+                    "%s: Skipping service without service instance id: %s",
                     self.name,
-                    service.uuid,
-                    service_iid_bytes,
-                    service_iid,
+                    service,
                 )
+                continue
 
+            service_iid_bytes = await self.client.read_gatt_char(
+                ble_service_char.handle
+            )
+            service_iid = int.from_bytes(service_iid_bytes, "little")
+            logger.debug(
+                "%s: Service %s iid: %s (decoded as %s)",
+                self.name,
+                service.uuid,
+                service_iid_bytes,
+                service_iid,
+            )
             s = accessory.add_service(normalize_uuid(service.uuid))
-
-            if service_iid:
-                s.iid = service_iid
+            s.iid = service_iid
 
             for char in service.characteristics:
                 if normalize_uuid(char.uuid) == SERVICE_INSTANCE_ID:


### PR DESCRIPTION
If we create them they will get assigned the next available one which will conflict with the actual one. We need to ignore these services as they are not homekit services but services defined by the vendor