### PR TITLE
Allow specifying the number of attempts with async_populate_accessories_state

### DIFF
--- a/aiohomekit/controller/abstract.py
+++ b/aiohomekit/controller/abstract.py
@@ -222,7 +222,7 @@ class AbstractPairing(metaclass=ABCMeta):
 
     @abstractmethod
     async def async_populate_accessories_state(
-        self, force_update: bool = False
+        self, force_update: bool = False, attempts: int | None = None
     ) -> None:
         """Populate the state of all accessories.
 

--- a/aiohomekit/controller/ble/connection.py
+++ b/aiohomekit/controller/ble/connection.py
@@ -38,7 +38,7 @@ async def establish_connection(
     device: BLEDevice,
     name: str,
     disconnected_callback: Callable[[AIOHomeKitBleakClient], None],
-    max_attempts: int = MAX_CONNECT_ATTEMPTS,
+    max_attempts: int | None = None,
     use_services_cache: bool = False,
     ble_device_callback: Callable[[BLEDevice], None] = None,
 ) -> AIOHomeKitBleakClient:
@@ -49,7 +49,7 @@ async def establish_connection(
             device,
             name,
             disconnected_callback,
-            max_attempts=max_attempts,
+            max_attempts=max_attempts or MAX_CONNECT_ATTEMPTS,
             use_services_cache=use_services_cache,
             ble_device_callback=ble_device_callback,
         )

--- a/aiohomekit/controller/coap/pairing.py
+++ b/aiohomekit/controller/coap/pairing.py
@@ -180,7 +180,7 @@ class CoAPPairing(ZeroconfPairing):
         """
 
     async def async_populate_accessories_state(
-        self, force_update: bool = False
+        self, force_update: bool = False, attempts: int | None = None
     ) -> bool:
         """Populate the state of all accessories.
 

--- a/aiohomekit/controller/coap/pairing.py
+++ b/aiohomekit/controller/coap/pairing.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from __future__ import annotations
 
 import asyncio
 from datetime import timedelta

--- a/aiohomekit/controller/ip/pairing.py
+++ b/aiohomekit/controller/ip/pairing.py
@@ -20,7 +20,7 @@ from datetime import timedelta
 from itertools import groupby
 import logging
 from operator import itemgetter
-from typing import Any, Optional
+from typing import Any
 
 from aiohomekit.controller.abstract import AbstractController, AbstractPairingData
 from aiohomekit.exceptions import (

--- a/aiohomekit/controller/ip/pairing.py
+++ b/aiohomekit/controller/ip/pairing.py
@@ -369,7 +369,7 @@ class IpPairing(ZeroconfPairing):
         return status
 
     async def async_populate_accessories_state(
-        self, force_update: bool = False
+        self, force_update: bool = False, attempts: int | None = None
     ) -> bool:
         """Populate the state of all accessories.
 

--- a/aiohomekit/controller/ip/pairing.py
+++ b/aiohomekit/controller/ip/pairing.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from __future__ import annotations
 
 import asyncio
 from datetime import timedelta

--- a/aiohomekit/controller/ip/pairing.py
+++ b/aiohomekit/controller/ip/pairing.py
@@ -525,7 +525,7 @@ class IpPairing(ZeroconfPairing):
 
         return resp.body
 
-    def _async_description_update(self, description: Optional[HomeKitService]) -> None:
+    def _async_description_update(self, description: HomeKitService | None) -> None:
         """We have new zeroconf metadata for this device."""
         super()._async_description_update(description)
 

--- a/aiohomekit/testing.py
+++ b/aiohomekit/testing.py
@@ -254,7 +254,7 @@ class FakePairing(AbstractPairing):
         self._ensure_connected()
 
     async def async_populate_accessories_state(
-        self, force_update: bool = False
+        self, force_update: bool = False, attempts: int | None = None
     ) -> bool:
         """Populate the state of all accessories.
 


### PR DESCRIPTION
Currently we only use this value for BLE connections

The goal is to fail quickly at startup so we do not block HASS startup and let the retry logic take over after startup to get the device up and going