### PR TITLE
Fallback to disconnected events when receiving encrypted notify without having the key yet

### DIFF
--- a/aiohomekit/controller/ble/pairing.py
+++ b/aiohomekit/controller/ble/pairing.py
@@ -472,10 +472,12 @@ class BlePairing(AbstractPairing):
         """Receive a notification from the accessory."""
         if not self._broadcast_decryption_key:
             logger.debug(
-                "%s: Received notification before session is setup, ignoring: %s",
+                "%s: Received notification before session is setup, "
+                "falling back processing as disconnected event: %s",
                 self.name,
                 data,
             )
+            async_create_task(self._process_disconnected_events())
             return
 
         start_state_num = self.description.state_num


### PR DESCRIPTION
If the device is asleep at startup we will not have the key when it wakes up and sends us a notification.