### PR TITLE
Add workaround for older eve devices

### DIFF
--- a/aiohomekit/controller/ble/pairing.py
+++ b/aiohomekit/controller/ble/pairing.py
@@ -644,8 +644,14 @@ class BlePairing(AbstractPairing):
                     continue
 
                 decoded = CharacteristicTLV.decode(signature).to_dict()
+                normalized_uuid = normalize_uuid(char.uuid)
 
-                hap_char = s.add_char(normalize_uuid(char.uuid))
+                if normalized_uuid == CharacteristicsTypes.IDENTIFY:
+                    # Workaround for older eve v1 devices which has a broken identify characteristic
+                    # that presents identify as data.
+                    decoded["format"] = "bool"
+
+                hap_char = s.add_char(normalized_uuid)
                 logger.debug("%s: char: %s decoded: %s", self.name, char, decoded)
 
                 hap_char.iid = iid


### PR DESCRIPTION
If this turns out to be more common we will probably need a function to handle additional workarounds. Since iOS is forgiving for this we should be as well

fixes https://github.com/home-assistant/core/issues/80177