### PR TITLE
Fix for various races with encrypted notifications

### DIFF
--- a/aiohomekit/controller/ble/pairing.py
+++ b/aiohomekit/controller/ble/pairing.py
@@ -868,15 +868,15 @@ class BlePairing(AbstractPairing):
 
             self._tried_to_connect_once = True
 
-            needed_to_connect = await self._ensure_connected(attempts)
+            made_connection = await self._ensure_connected(attempts)
 
             logger.debug(
-                "%s: Populating accessories and characteristics: needed_to_connect=%s restore_pending=%s",
+                "%s: Populating accessories and characteristics: made_connection=%s restore_pending=%s",
                 self.name,
-                needed_to_connect,
+                made_connection,
                 self._restore_pending,
             )
-            self._restore_pending |= needed_to_connect
+            self._restore_pending |= made_connection
 
             if was_locked and not force_update:
                 # No need to do it twice if we already have the data

--- a/aiohomekit/controller/ble/pairing.py
+++ b/aiohomekit/controller/ble/pairing.py
@@ -476,7 +476,7 @@ class BlePairing(AbstractPairing):
                 self.rssi,
             )
             try:
-                protocol_param, results = self._process_disconnected_events_with_retry()
+                protocol_param, results = await self._process_disconnected_events_with_retry()
             except (
                 AccessoryDisconnectedError,
                 *BLEAK_EXCEPTIONS,

--- a/aiohomekit/controller/ble/pairing.py
+++ b/aiohomekit/controller/ble/pairing.py
@@ -1206,7 +1206,7 @@ class BlePairing(AbstractPairing):
             return
         logger.debug("%s: subscribing to %s", self.name, new_chars)
         await self._populate_accessories_and_characteristics()
-        if not self._async_set_broadcast_encryption_key:
+        if not self._broadcast_decryption_key:
             await self._async_set_broadcast_encryption_key()
         await self._async_subscribe_broadcast_events(new_chars)
         await self._async_start_notify_subscriptions(new_chars)

--- a/aiohomekit/controller/ble/pairing.py
+++ b/aiohomekit/controller/ble/pairing.py
@@ -613,6 +613,11 @@ class BlePairing(AbstractPairing):
                     "%s: Failed to set broadcast key, try un-paring and re-pairing the accessory.",
                     self.name,
                 )
+        long_term_pub_key_hex: str = self.pairing_data["iOSDeviceLTPK"]
+        long_term_pub_key_bytes = bytes.fromhex(long_term_pub_key_hex)
+        self._broadcast_decryption_key = BroadcastDecryptionKey(
+            self._derive(long_term_pub_key_bytes, b"Broadcast-Encryption-Key")
+        )
 
     async def _async_fetch_gatt_database(self) -> Accessories:
         logger.debug("%s: Fetching GATT database; rssi=%s", self.name, self.rssi)
@@ -965,11 +970,6 @@ class BlePairing(AbstractPairing):
             return
 
         await self._async_set_broadcast_encryption_key()
-        long_term_pub_key_hex: str = self.pairing_data["iOSDeviceLTPK"]
-        long_term_pub_key_bytes = bytes.fromhex(long_term_pub_key_hex)
-        self._broadcast_decryption_key = BroadcastDecryptionKey(
-            self._derive(long_term_pub_key_bytes, b"Broadcast-Encryption-Key")
-        )
         subscriptions = list(self.subscriptions)
         logger.debug(
             "%s: Connected, resuming subscriptions: %s; rssi=%s",

--- a/aiohomekit/controller/ble/pairing.py
+++ b/aiohomekit/controller/ble/pairing.py
@@ -476,7 +476,10 @@ class BlePairing(AbstractPairing):
                 self.rssi,
             )
             try:
-                protocol_param, results = await self._process_disconnected_events_with_retry()
+                (
+                    protocol_param,
+                    results,
+                ) = await self._process_disconnected_events_with_retry()
             except (
                 AccessoryDisconnectedError,
                 *BLEAK_EXCEPTIONS,


### PR DESCRIPTION
Also fixes a race where was_connected was wrong because we were waiting for the lock and by the time is was acquired the value was stale and we had to reconnect.

Before these changes I was able to get the eve button to fallback to disconnected events.  Now I can mash it over and over and I get broadcast events for everything

Reduces the latency of disconnected events by calling the listeners after each char is read to avoid waiting for everything to be read

Ensure we re-read the GSN after starting notify and after a notify so we are always in sync