### PR TITLE
Restore broadcast_key between restarts

### DIFF
--- a/aiohomekit/characteristic_cache.py
+++ b/aiohomekit/characteristic_cache.py
@@ -53,7 +53,11 @@ class CharacteristicCacheType(Protocol):
         pass
 
     def async_create_or_update_map(
-        self, homekit_id: str, config_num: int, accessories: list[Any]
+        self,
+        homekit_id: str,
+        config_num: int,
+        accessories: list[Any],
+        broadcast_key: bytes | None = None,
     ) -> Pairing:
         pass
 

--- a/aiohomekit/characteristic_cache.py
+++ b/aiohomekit/characteristic_cache.py
@@ -39,6 +39,7 @@ class Pairing(TypedDict):
 
     config_num: int
     accessories: list[Any]
+    broadcast_key: bytes | None
 
 
 class StorageLayout(TypedDict):
@@ -70,10 +71,16 @@ class CharacteristicCacheMemory:
         return self.storage_data.get(homekit_id)
 
     def async_create_or_update_map(
-        self, homekit_id: str, config_num: int, accessories: list[Any]
+        self,
+        homekit_id: str,
+        config_num: int,
+        accessories: list[Any],
+        broadcast_key: bytes | None = None,
     ) -> Pairing:
         """Create a new pairing cache."""
-        data = Pairing(config_num=config_num, accessories=accessories)
+        data = Pairing(
+            config_num=config_num, accessories=accessories, broadcast_key=broadcast_key
+        )
         self.storage_data[homekit_id] = data
         return data
 
@@ -101,10 +108,16 @@ class CharacteristicCacheFile(CharacteristicCacheMemory):
                     )
 
     def async_create_or_update_map(
-        self, homekit_id: str, config_num: int, accessories: list[Any]
+        self,
+        homekit_id: str,
+        config_num: int,
+        accessories: list[Any],
+        broadcast_key: bytes | None = None,
     ) -> Pairing:
         """Create a new pairing cache."""
-        data = super().async_create_or_update_map(homekit_id, config_num, accessories)
+        data = super().async_create_or_update_map(
+            homekit_id, config_num, accessories, broadcast_key
+        )
         self._do_save()
         return data
 

--- a/aiohomekit/characteristic_cache.py
+++ b/aiohomekit/characteristic_cache.py
@@ -39,7 +39,7 @@ class Pairing(TypedDict):
 
     config_num: int
     accessories: list[Any]
-    broadcast_key: bytes | None
+    broadcast_key: str | None
 
 
 class StorageLayout(TypedDict):
@@ -57,7 +57,7 @@ class CharacteristicCacheType(Protocol):
         homekit_id: str,
         config_num: int,
         accessories: list[Any],
-        broadcast_key: bytes | None = None,
+        broadcast_key: str | None = None,
     ) -> Pairing:
         pass
 
@@ -79,7 +79,7 @@ class CharacteristicCacheMemory:
         homekit_id: str,
         config_num: int,
         accessories: list[Any],
-        broadcast_key: bytes | None = None,
+        broadcast_key: str | None = None,
     ) -> Pairing:
         """Create a new pairing cache."""
         data = Pairing(

--- a/aiohomekit/controller/abstract.py
+++ b/aiohomekit/controller/abstract.py
@@ -187,16 +187,24 @@ class AbstractPairing(metaclass=ABCMeta):
             )
             return
         config_num = cache.get("config_num", 0)
+        broadcast_key = cache.get("broadcast_key")
         accessories = Accessories.from_list(cache["accessories"])
-        self._accessories_state = AccessoriesState(accessories, config_num)
+        self._accessories_state = AccessoriesState(
+            accessories, config_num, broadcast_key
+        )
         logger.debug("%s: Accessories cache loaded (c#: %d)", self.name, config_num)
 
     def restore_accessories_state(
-        self, accessories: list[dict[str, Any]], config_num: int
+        self,
+        accessories: list[dict[str, Any]],
+        config_num: int,
+        broadcast_key: bytes | None,
     ) -> None:
         """Restore accessories from cache."""
         accessories = Accessories.from_list(accessories)
-        self._accessories_state = AccessoriesState(accessories, config_num)
+        self._accessories_state = AccessoriesState(
+            accessories, config_num, broadcast_key
+        )
         self._update_accessories_state_cache()
 
     def _update_accessories_state_cache(self):

--- a/aiohomekit/controller/abstract.py
+++ b/aiohomekit/controller/abstract.py
@@ -167,8 +167,11 @@ class AbstractPairing(metaclass=ABCMeta):
                 repopulate_accessories = True
 
             elif (
-                not self.description
-                or description.state_num != self.description.state_num
+                self.description
+                # If the description is not yet set we should not process
+                # disconnect events as we have not yet populated the
+                # accessories state.
+                and description.state_num != self.description.state_num
             ):
                 # Only process disconnected events if the config number has
                 # not also changed since we will do a full repopulation

--- a/aiohomekit/controller/abstract.py
+++ b/aiohomekit/controller/abstract.py
@@ -167,11 +167,8 @@ class AbstractPairing(metaclass=ABCMeta):
                 repopulate_accessories = True
 
             elif (
-                self.description
-                # If the description is not yet set we should not process
-                # disconnect events as we have not yet populated the
-                # accessories state.
-                and description.state_num != self.description.state_num
+                not self.description
+                or description.state_num != self.description.state_num
             ):
                 # Only process disconnected events if the config number has
                 # not also changed since we will do a full repopulation

--- a/aiohomekit/controller/ble/pairing.py
+++ b/aiohomekit/controller/ble/pairing.py
@@ -85,7 +85,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# The discover timeout is how longer we will wait for and advertisement to be
+# The discover timeout is how long we will wait for and advertisement to be
 # received. If we don't get it in this time we will try again later since
 # the scanner is always running anyways.
 DISCOVER_TIMEOUT = 10

--- a/aiohomekit/controller/ble/pairing.py
+++ b/aiohomekit/controller/ble/pairing.py
@@ -277,13 +277,6 @@ class BlePairing(AbstractPairing):
             return timedelta(minutes=5)
         return timedelta(hours=24)
 
-    @property
-    def broadcast_key(self) -> bytes | None:
-        """Return the broadcast key."""
-        if not self._accessories_state:
-            return None
-        return self._accessories_state.broadcast_key
-
     def _is_available_at_time(self, monotonic: float) -> bool:
         """Check if we are considered available at the given time."""
         return self.is_connected or monotonic - self._last_seen < AVAILABILITY_INTERVAL

--- a/aiohomekit/controller/ble/pairing.py
+++ b/aiohomekit/controller/ble/pairing.py
@@ -928,9 +928,13 @@ class BlePairing(AbstractPairing):
             if self._shutdown:
                 return
 
-            self._tried_to_connect_once = True
-
-            made_connection = await self._ensure_connected(attempts)
+            try:
+                made_connection = await self._ensure_connected(attempts)
+            finally:
+                # Only set _tried_to_connect_once after the connection
+                # attempt is complete so we don't try to process disconnected
+                # events while we are still trying to connect.
+                self._tried_to_connect_once = True
 
             logger.debug(
                 "%s: Populating accessories and characteristics: made_connection=%s restore_pending=%s",

--- a/aiohomekit/controller/ble/pairing.py
+++ b/aiohomekit/controller/ble/pairing.py
@@ -85,7 +85,10 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-DISCOVER_TIMEOUT = 30
+# The discover timeout is how longer we will wait for and advertisement to be
+# received. If we don't get it in this time we will try again later since
+# the scanner is always running anyways.
+DISCOVER_TIMEOUT = 10
 
 # Battery powered devices may not broadcast once paired until
 # there is an event so we use a long availablity interval.

--- a/aiohomekit/model/__init__.py
+++ b/aiohomekit/model/__init__.py
@@ -354,3 +354,4 @@ class AccessoriesState:
 
     accessories: Accessories
     config_num: int
+    broadcast_key: bytes | None = None

--- a/aiohomekit/utils.py
+++ b/aiohomekit/utils.py
@@ -101,3 +101,17 @@ def domain_supported(domain) -> bool:
     if domain.endswith("._hap._udp.local.") and COAP_TRANSPORT_SUPPORTED:
         return True
     return False
+
+
+def serialize_broadcast_key(broadcast_key: bytes | None) -> str | None:
+    """Serialize a broadcast key to a string."""
+    if broadcast_key is None:
+        return None
+    return broadcast_key.hex()
+
+
+def deserialize_broadcast_key(broadcast_key: str | None) -> bytes | None:
+    """Deserialize a broadcast key from a string."""
+    if broadcast_key is None:
+        return None
+    return bytes.fromhex(broadcast_key)


### PR DESCRIPTION
TLDR: This fixes battery powered BLE devices that sleep for long intervals

Some accessories will sleep for a long time and only send broadcasted events which makes them have very long connection intervals to save battery. Since we need to connect to get a new broadcast key we now save the broadcast key between restarts to ensure we can decrypt the advertisements coming in even though we cannot make a connection to the device during startup. When we get a disconnected event later we will try again to connect and the device will be awake which will trigger a full sync

Additional details: https://github.com/home-assistant/core/pull/81211

fixes #215