### PR TITLE
Replace handle lookups with a combined service/char/iid lookup

### DIFF
--- a/aiohomekit/controller/abstract.py
+++ b/aiohomekit/controller/abstract.py
@@ -203,7 +203,12 @@ class AbstractPairing(metaclass=ABCMeta):
         self._accessories_state = AccessoriesState(
             accessories, config_num, deserialize_broadcast_key(broadcast_key_hex)
         )
-        logger.debug("%s: Accessories cache loaded (c#: %d)", self.name, config_num)
+        logger.debug(
+            "%s: Accessories cache loaded (c#: %d) (has broadcast_key: %s)",
+            self.name,
+            config_num,
+            bool(broadcast_key_hex),
+        )
 
     def restore_accessories_state(
         self,

--- a/aiohomekit/controller/ble/bleak.py
+++ b/aiohomekit/controller/ble/bleak.py
@@ -124,14 +124,6 @@ class AIOHomeKitBleakClient(BleakClientWithServiceCache):
                 possible_matching_iid = await self.get_characteristic_iid(
                     possible_matching_char
                 )
-                logger.debug(
-                    "%s: iid for %s/%s with handle %s is %s",
-                    self.__name,
-                    service_uuid,
-                    characteristic_uuid,
-                    possible_matching_char.handle,
-                    possible_matching_iid,
-                )
                 if iid == possible_matching_iid:
                     self._char_cache[cache_key] = possible_matching_char
                     return possible_matching_char

--- a/aiohomekit/controller/ble/bleak.py
+++ b/aiohomekit/controller/ble/bleak.py
@@ -104,6 +104,11 @@ class AIOHomeKitBleakClient(BleakClientWithServiceCache):
             return char
 
         if possible_matching_chars:
+            logger.debug(
+                "Service %s with characteristics %s is ambiguous",
+                service_uuid,
+                characteristic_uuid,
+            )
             if not iid:
                 raise ValueError(
                     f"The service {service_uuid} and {characteristic_uuid} "

--- a/aiohomekit/controller/ble/bleak.py
+++ b/aiohomekit/controller/ble/bleak.py
@@ -5,10 +5,10 @@ import logging
 from typing import Any
 import uuid
 
-from bleak.exc import BleakError
 from bleak.backends.characteristic import BleakGATTCharacteristic
-from bleak.backends.service import BleakGATTService
 from bleak.backends.device import BLEDevice
+from bleak.backends.service import BleakGATTService
+from bleak.exc import BleakError
 from bleak_retry_connector import BleakClientWithServiceCache
 
 from .const import HAP_MIN_REQUIRED_MTU

--- a/aiohomekit/controller/ble/bleak.py
+++ b/aiohomekit/controller/ble/bleak.py
@@ -102,20 +102,19 @@ class AIOHomeKitBleakClient(BleakClientWithServiceCache):
             char = possible_matching_chars[0]
             self._char_cache[cache_key] = char
             return char
-
-        elif not possible_matching_chars and not iid:
-            raise ValueError(
-                f"The service {service_uuid} and {characteristic_uuid} "
-                "maps more more than one handle, iid must be provided to disambiguate."
-            )
-
-        for possible_matching_char in possible_matching_chars:
-            possible_matching_iid = await self.get_characteristic_iid(
-                possible_matching_char
-            )
-            if iid == possible_matching_iid:
-                self._char_cache[cache_key] = possible_matching_char
-                return possible_matching_char
+        elif possible_matching_chars:
+            if not iid:
+                raise ValueError(
+                    f"The service {service_uuid} and {characteristic_uuid} "
+                    "maps more more than one handle, iid must be provided to disambiguate."
+                )
+            for possible_matching_char in possible_matching_chars:
+                possible_matching_iid = await self.get_characteristic_iid(
+                    possible_matching_char
+                )
+                if iid == possible_matching_iid:
+                    self._char_cache[cache_key] = possible_matching_char
+                    return possible_matching_char
 
         if not service_matched:
             available_services = [

--- a/aiohomekit/controller/ble/bleak.py
+++ b/aiohomekit/controller/ble/bleak.py
@@ -7,8 +7,6 @@ import uuid
 
 from bleak.backends.characteristic import BleakGATTCharacteristic
 from bleak.backends.device import BLEDevice
-from bleak.backends.service import BleakGATTService
-from bleak.exc import BleakError
 from bleak_retry_connector import BleakClientWithServiceCache
 
 from .const import HAP_MIN_REQUIRED_MTU

--- a/aiohomekit/controller/ble/bleak.py
+++ b/aiohomekit/controller/ble/bleak.py
@@ -118,7 +118,7 @@ class AIOHomeKitBleakClient(BleakClientWithServiceCache):
             if not iid:
                 raise ValueError(
                     f"{self.__name}: The service {service_uuid} and {characteristic_uuid} "
-                    "maps more more than one handle, iid must be provided to disambiguate."
+                    "maps to more than one handle, iid must be provided to disambiguate."
                 )
             for possible_matching_char in possible_matching_chars:
                 possible_matching_iid = await self.get_characteristic_iid(

--- a/aiohomekit/controller/ble/bleak.py
+++ b/aiohomekit/controller/ble/bleak.py
@@ -102,7 +102,8 @@ class AIOHomeKitBleakClient(BleakClientWithServiceCache):
             char = possible_matching_chars[0]
             self._char_cache[cache_key] = char
             return char
-        elif possible_matching_chars:
+
+        if possible_matching_chars:
             if not iid:
                 raise ValueError(
                     f"The service {service_uuid} and {characteristic_uuid} "

--- a/aiohomekit/controller/ble/bleak.py
+++ b/aiohomekit/controller/ble/bleak.py
@@ -97,7 +97,7 @@ class AIOHomeKitBleakClient(BleakClientWithServiceCache):
                 for char in service.characteristics:
                     if char.uuid.lower() == characteristic_uuid.lower():
                         possible_matching_chars.append(char)
-        
+
         if len(possible_matching_chars) == 1:
             char = possible_matching_chars[0]
             self._char_cache[cache_key] = char
@@ -110,7 +110,9 @@ class AIOHomeKitBleakClient(BleakClientWithServiceCache):
             )
 
         for possible_matching_char in possible_matching_chars:
-            possible_matching_iid = await self.get_characteristic_iid(possible_matching_char)
+            possible_matching_iid = await self.get_characteristic_iid(
+                possible_matching_char
+            )
             if iid == possible_matching_iid:
                 self._char_cache[cache_key] = possible_matching_char
                 return possible_matching_char

--- a/aiohomekit/controller/ble/client.py
+++ b/aiohomekit/controller/ble/client.py
@@ -221,7 +221,7 @@ async def drive_pairing_state_machine(
     characteristic: str,
     state_machine: Generator[tuple[list[tuple[TLV, bytes]], list[TLV]], Any, Any],
 ) -> Any:
-    char = client.get_characteristic(ServicesTypes.PAIRING, characteristic)
+    char = await client.get_characteristic(ServicesTypes.PAIRING, characteristic)
     iid = await client.get_characteristic_iid(char)
 
     request, expected = state_machine.send(None)

--- a/aiohomekit/controller/ble/discovery.py
+++ b/aiohomekit/controller/ble/discovery.py
@@ -120,7 +120,7 @@ class BleDiscovery(AbstractDiscovery):
         await self._ensure_connected()
 
         try:
-            ff_char = self.client.get_characteristic(
+            ff_char = await self.client.get_characteristic(
                 ServicesTypes.PAIRING,
                 CharacteristicsTypes.PAIRING_FEATURES,
             )
@@ -129,7 +129,7 @@ class BleDiscovery(AbstractDiscovery):
             # we need to reconnect since our client is now invalid.
             await self._close()
             await self._ensure_connected()
-            ff_char = self.client.get_characteristic(
+            ff_char = await self.client.get_characteristic(
                 ServicesTypes.PAIRING,
                 CharacteristicsTypes.PAIRING_FEATURES,
             )
@@ -204,7 +204,7 @@ class BleDiscovery(AbstractDiscovery):
 
         await self._ensure_connected()
 
-        char = self.client.get_characteristic(
+        char = await self.client.get_characteristic(
             ServicesTypes.ACCESSORY_INFORMATION,
             CharacteristicsTypes.IDENTIFY,
         )

--- a/aiohomekit/controller/ble/pairing.py
+++ b/aiohomekit/controller/ble/pairing.py
@@ -1195,7 +1195,13 @@ class BlePairing(AbstractPairing):
                             char.type,
                         )
                         continue
-                    raise
+                    logger.exception(
+                        "%s: Reading characteristic %s resulted in an error: %s",
+                        self.name,
+                        char.type,
+                        ex,
+                    )
+                    continue
 
                 decoded = dict(TLV.decode_bytes(data))[1]
 

--- a/aiohomekit/controller/ble/pairing.py
+++ b/aiohomekit/controller/ble/pairing.py
@@ -337,17 +337,12 @@ class BlePairing(AbstractPairing):
             logger.debug("%s: Client not connected; rssi=%s", self.name, self.rssi)
             raise AccessoryDisconnectedError(f"{self.name} is not connected")
 
-        if char.handle:
-            endpoint = self.client.get_characteristic_by_handle(char.handle)
-        else:
-            endpoint = self.client.get_characteristic(char.service.type, char.type)
-
         pdu_status, result_data = await ble_request(
             self.client,
             self._encryption_key,
             self._decryption_key,
             opcode,
-            endpoint,
+            self.client.get_characteristic(char.service.type, char.type),
             iid if iid is not None else char.iid,
             data,
         )
@@ -412,10 +407,7 @@ class BlePairing(AbstractPairing):
         char = self.accessories.aid(BLE_AID).characteristics.iid(iid)
 
         # Find the GATT Characteristic object for this iid
-        if char.handle:
-            endpoint = self.client.get_characteristic_by_handle(char.handle)
-        else:
-            endpoint = self.client.get_characteristic(char.service.type, char.type)
+        endpoint = self.client.get_characteristic(char.service.type, char.type)
 
         # We only want to allow one in flight read
         # and one pending read at a time since there

--- a/aiohomekit/controller/ble/pairing.py
+++ b/aiohomekit/controller/ble/pairing.py
@@ -1192,6 +1192,8 @@ class BlePairing(AbstractPairing):
                             char.type,
                         )
                         continue
+                    raise
+
                 decoded = dict(TLV.decode_bytes(data))[1]
 
                 logger.debug(

--- a/aiohomekit/controller/ble/pairing.py
+++ b/aiohomekit/controller/ble/pairing.py
@@ -846,7 +846,9 @@ class BlePairing(AbstractPairing):
         for char in chars:
             result = results.get((BLE_AID, char.iid))
             if not result or "value" not in result:
-                logger.debug("%s: No value for %s", self.name, char)
+                logger.debug(
+                    "%s: No value for %s/%s", self.name, char.service.type, char.type
+                )
                 continue
             char.value = result["value"]
 

--- a/aiohomekit/controller/ble/pairing.py
+++ b/aiohomekit/controller/ble/pairing.py
@@ -542,7 +542,7 @@ class BlePairing(AbstractPairing):
 
     def _async_notification(self, data: HomeKitEncryptedNotification) -> None:
         """Receive a notification from the accessory."""
-        if not self._broadcast_decryption_key or not self.description:
+        if not self._broadcast_decryption_key:
             logger.debug(
                 "%s: Received notification before session is setup, "
                 "falling back processing as disconnected event: %s",
@@ -550,6 +550,13 @@ class BlePairing(AbstractPairing):
                 data,
             )
             async_create_task(self._process_disconnected_events())
+            return
+
+        if not self.description:
+            logger.error(
+                "%s: Received encrypted notification before advertisement.",
+                self.name,
+            )
             return
 
         start_state_num = self.description.state_num

--- a/aiohomekit/controller/ble/pairing.py
+++ b/aiohomekit/controller/ble/pairing.py
@@ -542,7 +542,7 @@ class BlePairing(AbstractPairing):
 
     def _async_notification(self, data: HomeKitEncryptedNotification) -> None:
         """Receive a notification from the accessory."""
-        if not self._broadcast_decryption_key:
+        if not self._broadcast_decryption_key or not self.description:
             logger.debug(
                 "%s: Received notification before session is setup, "
                 "falling back processing as disconnected event: %s",

--- a/aiohomekit/controller/ble/pairing.py
+++ b/aiohomekit/controller/ble/pairing.py
@@ -337,13 +337,16 @@ class BlePairing(AbstractPairing):
             logger.debug("%s: Client not connected; rssi=%s", self.name, self.rssi)
             raise AccessoryDisconnectedError(f"{self.name} is not connected")
 
+        endpoint_iid = iid if iid is not None else char.iid
+        endpoint = await self.client.get_characteristic(char.service.type, char.type, endpoint_iid)
+
         pdu_status, result_data = await ble_request(
             self.client,
             self._encryption_key,
             self._decryption_key,
             opcode,
-            self.client.get_characteristic(char.service.type, char.type),
-            iid if iid is not None else char.iid,
+            endpoint,
+            endpoint_iid,
             data,
         )
 
@@ -407,7 +410,7 @@ class BlePairing(AbstractPairing):
         char = self.accessories.aid(BLE_AID).characteristics.iid(iid)
 
         # Find the GATT Characteristic object for this iid
-        endpoint = self.client.get_characteristic(char.service.type, char.type)
+        endpoint = await self.client.get_characteristic(char.service.type, char.type)
 
         # We only want to allow one in flight read
         # and one pending read at a time since there

--- a/aiohomekit/controller/ble/pairing.py
+++ b/aiohomekit/controller/ble/pairing.py
@@ -1190,15 +1190,17 @@ class BlePairing(AbstractPairing):
                     # we need to skip in this case.
                     if ex.status == PDUStatus.INVALID_REQUEST:
                         logger.debug(
-                            "%s: Reading characteristic %s resulted in an invalid request (skipped)",
+                            "%s: Reading characteristic %s with iid %s resulted in an invalid request (skipped)",
                             self.name,
+                            char.iid,
                             char.type,
                         )
                         continue
                     logger.exception(
-                        "%s: Reading characteristic %s resulted in an error: %s",
+                        "%s: Reading characteristic %s with iid %s resulted in an error: %s",
                         self.name,
                         char.type,
+                        char.iid,
                         ex,
                     )
                     continue

--- a/aiohomekit/controller/ble/pairing.py
+++ b/aiohomekit/controller/ble/pairing.py
@@ -108,12 +108,15 @@ SKIP_SYNC_SERVICES = {
 }
 # These characteristics are not readable unless there has been a write
 WRITE_FIRST_REQUIRED_CHARACTERISTICS = {
-    "00000131-0000-1000-8000-0026BB765291",  # Setup Data Stream Transport
-    "00000117-0000-1000-8000-0026BB765291",  # Selected RTP Stream Configuration
-    "00000118-0000-1000-8000-0026BB765291",  # Setup Endpoints
+    CharacteristicsTypes.SETUP_DATA_STREAM_TRANSPORT,  # Setup Data Stream Transport
+    CharacteristicsTypes.SELECTED_RTP_STREAM_CONFIGURATION,  # Selected RTP Stream Configuration
+    CharacteristicsTypes.SETUP_ENDPOINTS,  # Setup Endpoints
     "00000138-0000-1000-8000-0026BB765291",  # Unknown write first characteristic
     "246912DC-8FA3-82ED-DEA4-9EB91D8FC2EE",  # Unknown Vendor char seen on Belkin Wemo Switch
 }
+IGNORE_READ_CHARACTERISTICS = {
+    CharacteristicsTypes.SERVICE_SIGNATURE
+} | WRITE_FIRST_REQUIRED_CHARACTERISTICS
 BLE_AID = 1  # The aid for BLE devices is always 1
 
 ENABLE_BROADCAST_PAYLOAD = TLV.encode_list(
@@ -825,7 +828,7 @@ class BlePairing(AbstractPairing):
             ):
                 continue
             for char in service.characteristics:
-                if char.type in WRITE_FIRST_REQUIRED_CHARACTERISTICS:
+                if char.type in IGNORE_READ_CHARACTERISTICS:
                     continue
                 if CharacteristicPermissions.paired_read not in char.perms:
                     continue
@@ -1169,9 +1172,9 @@ class BlePairing(AbstractPairing):
 
         async with self._ble_request_lock:
             for char in characteristics:
-                if char.type in WRITE_FIRST_REQUIRED_CHARACTERISTICS:
+                if char.type in IGNORE_READ_CHARACTERISTICS:
                     logger.debug(
-                        "%s: Ignoring write first only characteristic %s",
+                        "%s: Ignoring characteristic %s",
                         self.name,
                         char.iid,
                     )

--- a/aiohomekit/controller/ble/pairing.py
+++ b/aiohomekit/controller/ble/pairing.py
@@ -415,7 +415,9 @@ class BlePairing(AbstractPairing):
         char = self.accessories.aid(BLE_AID).characteristics.iid(iid)
 
         # Find the GATT Characteristic object for this iid
-        endpoint = await self.client.get_characteristic(char.service.type, char.type)
+        endpoint = await self.client.get_characteristic(
+            char.service.type, char.type, iid
+        )
 
         # We only want to allow one in flight read
         # and one pending read at a time since there

--- a/aiohomekit/controller/ble/pairing.py
+++ b/aiohomekit/controller/ble/pairing.py
@@ -1222,7 +1222,7 @@ class BlePairing(AbstractPairing):
                     logger.debug(
                         "%s: Failed to decode characteristic for %s from %s: %s",
                         self.name,
-                        char,
+                        char.type,
                         decoded,
                         ex,
                     )

--- a/aiohomekit/controller/ble/pairing.py
+++ b/aiohomekit/controller/ble/pairing.py
@@ -338,7 +338,9 @@ class BlePairing(AbstractPairing):
             raise AccessoryDisconnectedError(f"{self.name} is not connected")
 
         endpoint_iid = iid if iid is not None else char.iid
-        endpoint = await self.client.get_characteristic(char.service.type, char.type, endpoint_iid)
+        endpoint = await self.client.get_characteristic(
+            char.service.type, char.type, endpoint_iid
+        )
 
         pdu_status, result_data = await ble_request(
             self.client,


### PR DESCRIPTION
- The ESP32s have unstable handles so we need another way to map services/chars on the ble stack. Since Bleak will raise BleakError if there is more than one service with the same uuid we now manually enumerate services and chars until we find a matching pair to avoid the need to use handles
- If the service + char combination is ambiguous, we will ready iids until we find a match