### PR TITLE
Ignore link local addresses

### DIFF
--- a/aiohomekit/controller/ble/pairing.py
+++ b/aiohomekit/controller/ble/pairing.py
@@ -17,13 +17,13 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from datetime import timedelta
 import logging
 import random
 import struct
 import time
-from typing import TYPE_CHECKING, Any, Iterable, TypeVar, cast
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 from uuid import UUID
 
 from bleak.backends.characteristic import BleakGATTCharacteristic

--- a/aiohomekit/controller/ble/structs.py
+++ b/aiohomekit/controller/ble/structs.py
@@ -13,10 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from collections.abc import Sequence
 from dataclasses import dataclass, field
 import enum
 import struct
-from typing import Any, Optional, Sequence, Union
+from typing import Any, Optional, Union
 
 from aiohomekit.tlv8 import TLVStruct, tlv_entry, u8, u16, u128
 


### PR DESCRIPTION
This should fix https://github.com/home-assistant/core/issues/80211 by replicating the old HA behaviour of dropping link local addresses.