### PR TITLE
Notify listeners of new state on successful BLE write

### DIFF
--- a/aiohomekit/controller/ble/pairing.py
+++ b/aiohomekit/controller/ble/pairing.py
@@ -1334,7 +1334,7 @@ class BlePairing(AbstractPairing):
                     }
                 if single_result["status"] == HapStatusCode.SUCCESS:
                     for listener in self.listeners:
-                        listener(single_result)
+                        listener({result_key: single_result})
                 results[result_key] = single_result
 
         return results

--- a/aiohomekit/controller/ble/pairing.py
+++ b/aiohomekit/controller/ble/pairing.py
@@ -1324,8 +1324,9 @@ class BlePairing(AbstractPairing):
                     }
                 # results only set on failure, no status is success
                 if not result:
-                    for listener in self.listeners:
-                        listener({result_key: {"value": value}})
+                    if CharacteristicPermissions.paired_read in char.perms:
+                        for listener in self.listeners:
+                            listener({result_key: {"value": value}})
                 else:
                     results[result_key] = result
 


### PR DESCRIPTION
It can take 3-10s depending on how slow the ble connection is for HA to update after a successful write. This sometimes makes the switch turn back off in HA after it was successful so we should callback the change as soon as we know the OpStatus is successful to avoid the flip-flop.  With the nanoleaf devices this can even take > 10s because of how many chars need to be read to sync.

This change ensures HA more accurately reflects the state of the device since the light strip would light up and than HA changed state 10-15s later