### PR TITLE
Fix initial zeroconf lookup on start take 2

### DIFF
--- a/aiohomekit/zeroconf.py
+++ b/aiohomekit/zeroconf.py
@@ -223,6 +223,7 @@ class ZeroconfController(AbstractController):
         ]
 
         logger.warning("zc_cache: %s", zc.cache.cache)
+        logger.warning("details: %s", zc.cache.get_all_by_details(self.hap_type, TYPE_PTR, CLASS_IN))
         logger.warning("Found %s %s devices: %s", len(infos), self.hap_type, infos)
 
         tasks = []

--- a/aiohomekit/zeroconf.py
+++ b/aiohomekit/zeroconf.py
@@ -209,7 +209,7 @@ class ZeroconfController(AbstractController):
 
     def _async_get_ptr_records(self, zc: Zeroconf) -> list[DNSPointer]:
         """Return all PTR records for the HAP type."""
-        return zc.cache.get_all_by_details(self.hap_type, TYPE_PTR, CLASS_IN)
+        return zc.cache.async_all_by_details(self.hap_type, TYPE_PTR, CLASS_IN)
 
     async def async_start(self):
         zc = self._async_zeroconf_instance.zeroconf

--- a/aiohomekit/zeroconf.py
+++ b/aiohomekit/zeroconf.py
@@ -25,7 +25,7 @@ from ipaddress import ip_address
 import logging
 
 import async_timeout
-from zeroconf import ServiceListener, ServiceStateChange, Zeroconf, DNSPointer
+from zeroconf import DNSPointer, ServiceListener, ServiceStateChange, Zeroconf
 from zeroconf.asyncio import AsyncServiceBrowser, AsyncServiceInfo, AsyncZeroconf
 
 from aiohomekit.characteristic_cache import CharacteristicCacheType

--- a/aiohomekit/zeroconf.py
+++ b/aiohomekit/zeroconf.py
@@ -222,6 +222,7 @@ class ZeroconfController(AbstractController):
             for record in zc.cache.get_all_by_details(self.hap_type, TYPE_PTR, CLASS_IN)
         ]
 
+        logger.warning("zc_cache: %s", zc.cache.cache)
         logger.warning("Found %s %s devices: %s", len(infos), self.hap_type, infos)
 
         tasks = []

--- a/aiohomekit/zeroconf.py
+++ b/aiohomekit/zeroconf.py
@@ -224,7 +224,7 @@ class ZeroconfController(AbstractController):
 
         logger.warning("zc_cache: %s", zc.cache.cache)
         logger.warning("details: %s", zc.cache.get_all_by_details(self.hap_type, TYPE_PTR, CLASS_IN))
-        logger.warning("Found %s %s devices: %s", len(infos), self.hap_type, infos)
+#        logger.warning("Found %s %s devices: %s", len(infos), self.hap_type, infos)
 
         tasks = []
         for info in infos:

--- a/aiohomekit/zeroconf.py
+++ b/aiohomekit/zeroconf.py
@@ -222,6 +222,8 @@ class ZeroconfController(AbstractController):
             for record in zc.cache.get_all_by_details(self.hap_type, TYPE_PTR, CLASS_IN)
         ]
 
+        logger.warning("Found %s %s devices: %s", len(infos), self.hap_type, infos)
+
         tasks = []
         for info in infos:
             if info.load_from_cache(self._async_zeroconf_instance.zeroconf):

--- a/aiohomekit/zeroconf.py
+++ b/aiohomekit/zeroconf.py
@@ -226,9 +226,6 @@ class ZeroconfController(AbstractController):
             for record in self._async_get_ptr_records(zc)
         ]
 
-        logger.warning("details: %s", self._async_get_ptr_records(zc))
-#        logger.warning("Found %s %s devices: %s", len(infos), self.hap_type, infos)
-
         tasks = []
         for info in infos:
             if info.load_from_cache(self._async_zeroconf_instance.zeroconf):

--- a/aiohomekit/zeroconf.py
+++ b/aiohomekit/zeroconf.py
@@ -211,7 +211,7 @@ class ZeroconfController(AbstractController):
         """Return all PTR records for the HAP type."""
         return zc.cache.async_all_by_details(self.hap_type, TYPE_PTR, CLASS_IN)
 
-    async def _async_load_from_cache(self, zc: Zeroconf) -> None:
+    async def _async_update_from_cache(self, zc: Zeroconf) -> None:
         """Load the records from the cache."""
         infos = [
             AsyncServiceInfo(self.hap_type, record.alias)
@@ -236,7 +236,7 @@ class ZeroconfController(AbstractController):
             self._async_zeroconf_instance, self.hap_type
         )
         self._browser.service_state_changed.register_handler(self._handle_service)
-        await self._async_load_from_cache(zc)
+        await self._async_update_from_cache(zc)
 
         return self
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ from unittest import mock
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from zeroconf import SignalRegistrationInterface
+from zeroconf import SignalRegistrationInterface, DNSCache
 
 from aiohomekit import Controller
 from aiohomekit.controller.ip import IpPairing
@@ -70,6 +70,7 @@ def mock_asynczeroconf():
             zc.async_register_service = AsyncMock()
             zc.async_close = AsyncMock()
             zeroconf = MagicMock(name="zeroconf_mock")
+            zeroconf.cache = DNSCache()
             zeroconf.async_wait_for_start = AsyncMock()
             zeroconf.listeners = [AsyncServiceBrowserStub()]
             zc.zeroconf = zeroconf

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ from unittest import mock
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from zeroconf import SignalRegistrationInterface, DNSCache
+from zeroconf import DNSCache, SignalRegistrationInterface
 
 from aiohomekit import Controller
 from aiohomekit.controller.ip import IpPairing

--- a/tests/test_controller_ip_controller.py
+++ b/tests/test_controller_ip_controller.py
@@ -37,7 +37,7 @@ def _install_mock_service_info(mock_asynczeroconf) -> Iterable[AsyncServiceInfo]
     mock_asynczeroconf.zeroconf.cache = MagicMock(
         async_all_by_details=MagicMock(
             return_value=[
-                MagicMock(alias="foo._hap._tcp.local."),
+                MagicMock(name="_hap._tcp.local.", alias="foo._hap._tcp.local."),
             ]
         )
     )

--- a/tests/test_controller_ip_controller.py
+++ b/tests/test_controller_ip_controller.py
@@ -75,7 +75,7 @@ async def test_discover_find_one(mock_asynczeroconf: AsyncZeroconf):
     with _install_mock_service_info(mock_asynczeroconf, _get_mock_service_info()):
         async with controller:
             result = await controller.async_find("00:00:01:00:00:02")
-        await controller._async_load_from_cache(mock_asynczeroconf.zeroconf)
+        await controller._async_update_from_cache(mock_asynczeroconf.zeroconf)
 
     assert result.description.id == "00:00:01:00:00:02"
     assert result.description.category == Categories.LIGHTBULB
@@ -97,7 +97,7 @@ async def test_discover_find_one_unpaired(mock_asynczeroconf: AsyncZeroconf):
     with _install_mock_service_info(mock_asynczeroconf, svc):
         async with controller:
             result = await controller.async_find("00:00:01:00:00:02")
-        await controller._async_load_from_cache(mock_asynczeroconf.zeroconf)
+        await controller._async_update_from_cache(mock_asynczeroconf.zeroconf)
 
     assert result.description.id == "00:00:01:00:00:02"
     assert result.description.status_flags == StatusFlags.UNPAIRED
@@ -125,7 +125,7 @@ async def test_find_device_id_case_lower(mock_asynczeroconf: AsyncZeroconf):
 
     with _install_mock_service_info(mock_asynczeroconf, svc_info_1):
         async with controller:
-            await controller._async_load_from_cache(mock_asynczeroconf.zeroconf)
+            await controller._async_update_from_cache(mock_asynczeroconf.zeroconf)
             res = await controller.async_find("AA:AA:AA:AA:AA:AA")
             assert res.description.id == "aa:aa:aa:aa:aa:aa"
 
@@ -137,7 +137,7 @@ async def test_find_device_id_case_lower(mock_asynczeroconf: AsyncZeroconf):
         svc_info_2.properties[b"id"] = b"aa:aa:aa:aa:aa:aa"
 
         async with controller:
-            await controller._async_load_from_cache(mock_asynczeroconf.zeroconf)
+            await controller._async_update_from_cache(mock_asynczeroconf.zeroconf)
             res = await controller.async_find("aa:aa:aa:aa:aa:aa")
             assert res.description.id == "aa:aa:aa:aa:aa:aa"
 
@@ -153,7 +153,7 @@ async def test_find_device_id_case_upper(mock_asynczeroconf: AsyncZeroconf):
 
     with _install_mock_service_info(mock_asynczeroconf, svc_info):
         async with controller:
-            await controller._async_load_from_cache(mock_asynczeroconf.zeroconf)
+            await controller._async_update_from_cache(mock_asynczeroconf.zeroconf)
             res = await controller.async_find("AA:AA:AA:AA:AA:AA")
             assert res.description.id == "aa:aa:aa:aa:aa:aa"
 
@@ -164,7 +164,7 @@ async def test_find_device_id_case_upper(mock_asynczeroconf: AsyncZeroconf):
     with _install_mock_service_info(mock_asynczeroconf, svc_info):
 
         async with controller:
-            await controller._async_load_from_cache(mock_asynczeroconf.zeroconf)
+            await controller._async_update_from_cache(mock_asynczeroconf.zeroconf)
             res = await controller.async_find("aa:aa:aa:aa:aa:aa")
             assert res.description.id == "aa:aa:aa:aa:aa:aa"
 
@@ -177,7 +177,7 @@ async def test_discover_discover_one(mock_asynczeroconf: AsyncZeroconf):
     srv_info = _get_mock_service_info()
     with _install_mock_service_info(mock_asynczeroconf, srv_info):
         async with controller:
-            await controller._async_load_from_cache(mock_asynczeroconf.zeroconf)
+            await controller._async_update_from_cache(mock_asynczeroconf.zeroconf)
             results = [d async for d in controller.async_discover()]
 
     assert results[0].description.id == "00:00:01:00:00:02"
@@ -209,7 +209,7 @@ async def test_discover_missing_csharp(mock_asynczeroconf: AsyncZeroconf):
 
     with _install_mock_service_info(mock_asynczeroconf, svc_info):
         async with controller:
-            await controller._async_load_from_cache(mock_asynczeroconf.zeroconf)
+            await controller._async_update_from_cache(mock_asynczeroconf.zeroconf)
             results = [d async for d in controller.async_discover()]
 
     assert results[0].description.id == "00:00:01:00:00:02"
@@ -228,7 +228,7 @@ async def test_discover_csharp_case(mock_asynczeroconf: AsyncZeroconf):
 
     with _install_mock_service_info(mock_asynczeroconf, svc_info):
         async with controller:
-            await controller._async_load_from_cache(mock_asynczeroconf.zeroconf)
+            await controller._async_update_from_cache(mock_asynczeroconf.zeroconf)
             results = [d async for d in controller.async_discover()]
 
     assert results[0].description.config_num == 1
@@ -246,7 +246,7 @@ async def test_discover_device_id_case_lower(mock_asynczeroconf: AsyncZeroconf):
     with _install_mock_service_info(mock_asynczeroconf, svc_info):
 
         async with controller:
-            await controller._async_load_from_cache(mock_asynczeroconf.zeroconf)
+            await controller._async_update_from_cache(mock_asynczeroconf.zeroconf)
 
             results = [d async for d in controller.async_discover()]
 
@@ -265,7 +265,7 @@ async def test_discover_device_id_case_upper(mock_asynczeroconf: AsyncZeroconf):
     with _install_mock_service_info(mock_asynczeroconf, svc_info):
 
         async with controller:
-            await controller._async_load_from_cache(mock_asynczeroconf.zeroconf)
+            await controller._async_update_from_cache(mock_asynczeroconf.zeroconf)
 
             results = [d async for d in controller.async_discover()]
 

--- a/tests/test_controller_ip_controller.py
+++ b/tests/test_controller_ip_controller.py
@@ -35,7 +35,7 @@ def _install_mock_service_info(mock_asynczeroconf) -> Iterable[AsyncServiceInfo]
     )
 
     mock_asynczeroconf.zeroconf.cache = MagicMock(
-        get_all_by_details=MagicMock(
+        async_all_by_details=MagicMock(
             return_value=[
                 MagicMock(alias="foo._hap._tcp.local."),
             ]

--- a/tests/test_controller_ip_controller.py
+++ b/tests/test_controller_ip_controller.py
@@ -11,10 +11,28 @@ from aiohomekit.controller.ip.controller import IpController
 from aiohomekit.exceptions import AccessoryNotFoundError
 from aiohomekit.model.categories import Categories
 from aiohomekit.model.status_flags import StatusFlags
+from typing import Optional
+from zeroconf import DNSQuestionType, Zeroconf
+from zeroconf.asyncio import AsyncZeroconf
 
 
-@contextlib.contextmanager
-def _install_mock_service_info(mock_asynczeroconf) -> Iterable[AsyncServiceInfo]:
+HAP_TYPE_TCP = "_hap._tcp.local."
+HAP_TYPE_UDP = "_hap._udp.local."
+CLASS_IN = 1
+TYPE_PTR = 12
+
+
+class MockedAsyncServiceInfo(AsyncServiceInfo):
+    async def async_request(
+        self,
+        zc: "Zeroconf",
+        timeout: float,
+        question_type: Optional[DNSQuestionType] = None,
+    ) -> bool:
+        return self.load_from_cache(zc)
+
+
+def _get_mock_service_info():
     desc = {
         b"c#": b"1",
         b"id": b"00:00:01:00:00:02",
@@ -23,10 +41,9 @@ def _install_mock_service_info(mock_asynczeroconf) -> Iterable[AsyncServiceInfo]
         b"ci": b"5",
         b"sf": b"0",
     }
-
-    info = AsyncServiceInfo(
-        "_hap._tcp.local.",
-        "foo._hap._tcp.local.",
+    return MockedAsyncServiceInfo(
+        HAP_TYPE_TCP,
+        f"foo.{HAP_TYPE_TCP}",
         addresses=[socket.inet_aton("127.0.0.1")],
         port=1234,
         properties=desc,
@@ -34,26 +51,33 @@ def _install_mock_service_info(mock_asynczeroconf) -> Iterable[AsyncServiceInfo]
         priority=0,
     )
 
-    mock_asynczeroconf.zeroconf.cache = MagicMock(
-        async_all_by_details=MagicMock(
-            return_value=[
-                MagicMock(name="_hap._tcp.local.", alias="foo._hap._tcp.local."),
-            ]
-        )
+
+@contextlib.contextmanager
+def _install_mock_service_info(
+    mock_asynczeroconf: AsyncZeroconf, info: MockedAsyncServiceInfo
+) -> Iterable[AsyncServiceInfo]:
+    zeroconf: Zeroconf = mock_asynczeroconf.zeroconf
+    zeroconf.cache.async_add_records(
+        [*info.dns_addresses(), info.dns_pointer(), info.dns_service(), info.dns_text()]
     )
 
-    with patch("aiohomekit.zeroconf.AsyncServiceInfo", side_effect=[info]):
-        yield info
+    assert (
+        zeroconf.cache.async_all_by_details(HAP_TYPE_TCP, TYPE_PTR, CLASS_IN)
+        is not None
+    )
+
+    with patch("aiohomekit.zeroconf.AsyncServiceInfo", MockedAsyncServiceInfo):
+        yield
 
 
-async def test_discover_find_one(mock_asynczeroconf):
+async def test_discover_find_one(mock_asynczeroconf: AsyncZeroconf):
     controller = IpController(
         char_cache=CharacteristicCacheMemory(), zeroconf_instance=mock_asynczeroconf
     )
-
-    with _install_mock_service_info(mock_asynczeroconf):
+    with _install_mock_service_info(mock_asynczeroconf, _get_mock_service_info()):
         async with controller:
             result = await controller.async_find("00:00:01:00:00:02")
+        await controller._async_load_from_cache(mock_asynczeroconf.zeroconf)
 
     assert result.description.id == "00:00:01:00:00:02"
     assert result.description.category == Categories.LIGHTBULB
@@ -64,15 +88,18 @@ async def test_discover_find_one(mock_asynczeroconf):
     assert result.paired is True
 
 
-async def test_discover_find_one_unpaired(mock_asynczeroconf):
+async def test_discover_find_one_unpaired(mock_asynczeroconf: AsyncZeroconf):
     controller = IpController(
         char_cache=CharacteristicCacheMemory(), zeroconf_instance=mock_asynczeroconf
     )
 
-    with _install_mock_service_info(mock_asynczeroconf) as svc:
-        svc.properties[b"sf"] = b"1"
+    svc = _get_mock_service_info()
+    svc.properties[b"sf"] = b"1"
+    svc._set_properties(svc.properties)
+    with _install_mock_service_info(mock_asynczeroconf, svc):
         async with controller:
             result = await controller.async_find("00:00:01:00:00:02")
+        await controller._async_load_from_cache(mock_asynczeroconf.zeroconf)
 
     assert result.description.id == "00:00:01:00:00:02"
     assert result.description.status_flags == StatusFlags.UNPAIRED
@@ -86,56 +113,73 @@ async def test_discover_find_none(mock_asynczeroconf):
 
     async with controller:
         with pytest.raises(AccessoryNotFoundError):
-            await controller.async_find("00:00:00:00:00:00")
+            await controller.async_find("00:00:00:00:00:00", timeout=0.001)
 
 
-async def test_find_device_id_case_lower(mock_asynczeroconf):
+async def test_find_device_id_case_lower(mock_asynczeroconf: AsyncZeroconf):
     controller = IpController(
         char_cache=CharacteristicCacheMemory(), zeroconf_instance=mock_asynczeroconf
     )
 
-    with _install_mock_service_info(mock_asynczeroconf) as svc_info:
-        svc_info.properties[b"id"] = b"aa:aa:aa:aa:aa:aa"
+    svc_info_1 = _get_mock_service_info()
+    svc_info_1.properties[b"id"] = b"aa:aa:aa:aa:aa:aa"
+    svc_info_1._set_properties(svc_info_1.properties)
 
+    with _install_mock_service_info(mock_asynczeroconf, svc_info_1):
         async with controller:
+            await controller._async_load_from_cache(mock_asynczeroconf.zeroconf)
             res = await controller.async_find("AA:AA:AA:AA:AA:AA")
             assert res.description.id == "aa:aa:aa:aa:aa:aa"
 
-    with _install_mock_service_info(mock_asynczeroconf) as svc_info:
-        svc_info.properties[b"id"] = b"aa:aa:aa:aa:aa:aa"
+    svc_info_2 = _get_mock_service_info()
+    svc_info_2.properties[b"id"] = b"aa:aa:aa:aa:aa:aa"
+    svc_info_2._set_properties(svc_info_2.properties)
+
+    with _install_mock_service_info(mock_asynczeroconf, svc_info_2):
+        svc_info_2.properties[b"id"] = b"aa:aa:aa:aa:aa:aa"
 
         async with controller:
+            await controller._async_load_from_cache(mock_asynczeroconf.zeroconf)
             res = await controller.async_find("aa:aa:aa:aa:aa:aa")
             assert res.description.id == "aa:aa:aa:aa:aa:aa"
 
 
-async def test_find_device_id_case_upper(mock_asynczeroconf):
+async def test_find_device_id_case_upper(mock_asynczeroconf: AsyncZeroconf):
     controller = IpController(
         char_cache=CharacteristicCacheMemory(), zeroconf_instance=mock_asynczeroconf
     )
 
-    with _install_mock_service_info(mock_asynczeroconf) as svc_info:
-        svc_info.properties[b"id"] = b"AA:AA:aa:aa:AA:AA"
+    svc_info = _get_mock_service_info()
+    svc_info.properties[b"id"] = b"AA:AA:aa:aa:AA:AA"
+    svc_info._set_properties(svc_info.properties)
 
+    with _install_mock_service_info(mock_asynczeroconf, svc_info):
         async with controller:
+            await controller._async_load_from_cache(mock_asynczeroconf.zeroconf)
             res = await controller.async_find("AA:AA:AA:AA:AA:AA")
             assert res.description.id == "aa:aa:aa:aa:aa:aa"
 
-    with _install_mock_service_info(mock_asynczeroconf) as svc_info:
-        svc_info.properties[b"id"] = b"AA:AA:aa:aa:AA:AA"
+    svc_info = _get_mock_service_info()
+    svc_info.properties[b"id"] = b"AA:AA:aa:aa:AA:AA"
+    svc_info._set_properties(svc_info.properties)
+
+    with _install_mock_service_info(mock_asynczeroconf, svc_info):
 
         async with controller:
+            await controller._async_load_from_cache(mock_asynczeroconf.zeroconf)
             res = await controller.async_find("aa:aa:aa:aa:aa:aa")
             assert res.description.id == "aa:aa:aa:aa:aa:aa"
 
 
-async def test_discover_discover_one(mock_asynczeroconf):
+async def test_discover_discover_one(mock_asynczeroconf: AsyncZeroconf):
     controller = IpController(
         char_cache=CharacteristicCacheMemory(), zeroconf_instance=mock_asynczeroconf
     )
 
-    with _install_mock_service_info(mock_asynczeroconf):
+    srv_info = _get_mock_service_info()
+    with _install_mock_service_info(mock_asynczeroconf, srv_info):
         async with controller:
+            await controller._async_load_from_cache(mock_asynczeroconf.zeroconf)
             results = [d async for d in controller.async_discover()]
 
     assert results[0].description.id == "00:00:01:00:00:02"
@@ -156,58 +200,75 @@ async def test_discover_none(mock_asynczeroconf):
     assert results == []
 
 
-async def test_discover_missing_csharp(mock_asynczeroconf):
+async def test_discover_missing_csharp(mock_asynczeroconf: AsyncZeroconf):
     controller = IpController(
         char_cache=CharacteristicCacheMemory(), zeroconf_instance=mock_asynczeroconf
     )
 
-    with _install_mock_service_info(mock_asynczeroconf) as svc_info:
-        del svc_info.properties[b"c#"]
+    svc_info = _get_mock_service_info()
+    del svc_info.properties[b"c#"]
+    svc_info._set_properties(svc_info.properties)
+
+    with _install_mock_service_info(mock_asynczeroconf, svc_info):
         async with controller:
+            await controller._async_load_from_cache(mock_asynczeroconf.zeroconf)
             results = [d async for d in controller.async_discover()]
 
     assert results[0].description.id == "00:00:01:00:00:02"
     assert results[0].description.config_num == 0
 
 
-async def test_discover_csharp_case(mock_asynczeroconf):
+async def test_discover_csharp_case(mock_asynczeroconf: AsyncZeroconf):
     controller = IpController(
         char_cache=CharacteristicCacheMemory(), zeroconf_instance=mock_asynczeroconf
     )
 
-    with _install_mock_service_info(mock_asynczeroconf) as svc_info:
-        del svc_info.properties[b"c#"]
-        svc_info.properties[b"C#"] = b"1"
+    svc_info = _get_mock_service_info()
+    del svc_info.properties[b"c#"]
+    svc_info.properties[b"C#"] = b"1"
+    svc_info._set_properties(svc_info.properties)
 
+    with _install_mock_service_info(mock_asynczeroconf, svc_info):
         async with controller:
+            await controller._async_load_from_cache(mock_asynczeroconf.zeroconf)
             results = [d async for d in controller.async_discover()]
 
     assert results[0].description.config_num == 1
 
 
-async def test_discover_device_id_case_lower(mock_asynczeroconf):
+async def test_discover_device_id_case_lower(mock_asynczeroconf: AsyncZeroconf):
     controller = IpController(
         char_cache=CharacteristicCacheMemory(), zeroconf_instance=mock_asynczeroconf
     )
 
-    with _install_mock_service_info(mock_asynczeroconf) as svc_info:
-        svc_info.properties[b"id"] = b"aa:aa:aa:aa:aa:aa"
+    svc_info = _get_mock_service_info()
+    svc_info.properties[b"id"] = b"aa:aa:aa:aa:aa:aa"
+    svc_info._set_properties(svc_info.properties)
+
+    with _install_mock_service_info(mock_asynczeroconf, svc_info):
 
         async with controller:
+            await controller._async_load_from_cache(mock_asynczeroconf.zeroconf)
+
             results = [d async for d in controller.async_discover()]
 
     assert results[0].description.id == "aa:aa:aa:aa:aa:aa"
 
 
-async def test_discover_device_id_case_upper(mock_asynczeroconf):
+async def test_discover_device_id_case_upper(mock_asynczeroconf: AsyncZeroconf):
     controller = IpController(
         char_cache=CharacteristicCacheMemory(), zeroconf_instance=mock_asynczeroconf
     )
 
-    with _install_mock_service_info(mock_asynczeroconf) as svc_info:
-        svc_info.properties[b"id"] = b"AA:AA:aa:aa:AA:AA"
+    svc_info = _get_mock_service_info()
+    svc_info.properties[b"id"] = b"AA:AA:aa:aa:AA:AA"
+    svc_info._set_properties(svc_info.properties)
+
+    with _install_mock_service_info(mock_asynczeroconf, svc_info):
 
         async with controller:
+            await controller._async_load_from_cache(mock_asynczeroconf.zeroconf)
+
             results = [d async for d in controller.async_discover()]
 
     assert results[0].description.id == "aa:aa:aa:aa:aa:aa"

--- a/tests/test_controller_ip_controller.py
+++ b/tests/test_controller_ip_controller.py
@@ -1,20 +1,18 @@
 from collections.abc import Iterable
 import contextlib
 import socket
+from typing import Optional
 from unittest.mock import patch
 
 import pytest
-from zeroconf.asyncio import AsyncServiceInfo
+from zeroconf import DNSQuestionType, Zeroconf
+from zeroconf.asyncio import AsyncServiceInfo, AsyncZeroconf
 
 from aiohomekit.characteristic_cache import CharacteristicCacheMemory
 from aiohomekit.controller.ip.controller import IpController
 from aiohomekit.exceptions import AccessoryNotFoundError
 from aiohomekit.model.categories import Categories
 from aiohomekit.model.status_flags import StatusFlags
-from typing import Optional
-from zeroconf import DNSQuestionType, Zeroconf
-from zeroconf.asyncio import AsyncZeroconf
-
 
 HAP_TYPE_TCP = "_hap._tcp.local."
 HAP_TYPE_UDP = "_hap._udp.local."

--- a/tests/test_controller_ip_controller.py
+++ b/tests/test_controller_ip_controller.py
@@ -1,7 +1,7 @@
 from collections.abc import Iterable
 import contextlib
 import socket
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 from zeroconf.asyncio import AsyncServiceInfo


### PR DESCRIPTION
#228 was actually the same root cause as the issue fixed by https://github.com/jstasiak/python-zeroconf/pull/1102 and we do want `.alias` here :man_facepalming: (PTR records are the only ones that need this), but we should use `async_all_by_details` instead of `get_all_by_details` since we are calling this in `async` context.

This reverts the change in #228 and wraps it in a new function that uses `async_all_by_details` and fixes the typing.

I also rewrote the tests so they are testing closer to what is in production so we avoid patching the zeroconf cache and the patch for `aiohomekit.zeroconf.AsyncServiceInfo` is now only patching out the `async_request` call instead of the whole object so we won't regress this.

I also fixed the `test_discover_find_none` taking 10s to run.

fixes #232