### PR TITLE
Force reconnect when GATT services are missing to re-resolve services

### DIFF
--- a/aiohomekit/controller/ble/bleak.py
+++ b/aiohomekit/controller/ble/bleak.py
@@ -7,8 +7,9 @@ import uuid
 
 from bleak.backends.characteristic import BleakGATTCharacteristic
 from bleak.backends.device import BLEDevice
-from bleak_retry_connector import BleakClientWithServiceCache
 from bleak.exc import BleakError
+from bleak_retry_connector import BleakClientWithServiceCache
+
 from .const import HAP_MIN_REQUIRED_MTU
 
 CHAR_DESCRIPTOR_ID = "DC46F0FE-81D2-4616-B5D9-6ABDD796939A"
@@ -20,6 +21,7 @@ ATT_HEADER_SIZE = 3
 
 class BleakCharacteristicMissing(BleakError):
     """Raised when a characteristic is missing from a service."""
+
 
 class BleakServiceMissing(BleakError):
     """Raised when a service is missing."""

--- a/aiohomekit/controller/ble/bleak.py
+++ b/aiohomekit/controller/ble/bleak.py
@@ -8,7 +8,7 @@ import uuid
 from bleak.backends.characteristic import BleakGATTCharacteristic
 from bleak.backends.device import BLEDevice
 from bleak_retry_connector import BleakClientWithServiceCache
-
+from bleak.exc import BleakError
 from .const import HAP_MIN_REQUIRED_MTU
 
 CHAR_DESCRIPTOR_ID = "DC46F0FE-81D2-4616-B5D9-6ABDD796939A"
@@ -16,6 +16,13 @@ CHAR_DESCRIPTOR_UUID = uuid.UUID(CHAR_DESCRIPTOR_ID)
 
 logger = logging.getLogger(__name__)
 ATT_HEADER_SIZE = 3
+
+
+class BleakCharacteristicMissing(BleakError):
+    """Raised when a characteristic is missing from a service."""
+
+class BleakServiceMissing(BleakError):
+    """Raised when a service is missing."""
 
 
 @lru_cache(maxsize=64, typed=True)
@@ -132,11 +139,11 @@ class AIOHomeKitBleakClient(BleakClientWithServiceCache):
             available_services = [
                 service.uuid for service in self.services.services.values()
             ]
-            raise ValueError(
+            raise BleakServiceMissing(
                 f"{self.__name}: Service {service_uuid} not found, available services: {available_services}"
             )
         available_chars = [char.uuid for char in service.characteristics]
-        raise ValueError(
+        raise BleakCharacteristicMissing(
             f"{self.__name}: Characteristic {characteristic_uuid} not found, available characteristics: {available_chars}"
         )
 

--- a/aiohomekit/controller/ble/pairing.py
+++ b/aiohomekit/controller/ble/pairing.py
@@ -177,6 +177,7 @@ def disconnect_on_missing_services(func: WrapFuncType) -> WrapFuncType:
             logger.warning(
                 "%s: Missing service or characteristic, disconnecting to force refetch of GATT services: %s",
                 self.name,
+                ex,
             )
             if self.client:
                 await self.client.disconnect()

--- a/aiohomekit/controller/ble/pairing.py
+++ b/aiohomekit/controller/ble/pairing.py
@@ -173,9 +173,9 @@ def disconnect_on_missing_services(func: WrapFuncType) -> WrapFuncType:
     ) -> None:
         try:
             return await func(self, *args, **kwargs)
-        except (BleakServiceMissing, BleakCharacteristicMissing):
+        except (BleakServiceMissing, BleakCharacteristicMissing) as ex:
             logger.warning(
-                "%s: Missing service or characteristic, disconnecting to force refetch of GATT services",
+                "%s: Missing service or characteristic, disconnecting to force refetch of GATT services: %s",
                 self.name,
             )
             if self.client:

--- a/aiohomekit/controller/ble/pairing.py
+++ b/aiohomekit/controller/ble/pairing.py
@@ -59,7 +59,11 @@ from aiohomekit.utils import async_create_task
 from aiohomekit.uuid import normalize_uuid
 
 from ..abstract import AbstractPairing, AbstractPairingData
-from .bleak import AIOHomeKitBleakClient, BleakCharacteristicMissing, BleakServiceMissing
+from .bleak import (
+    AIOHomeKitBleakClient,
+    BleakCharacteristicMissing,
+    BleakServiceMissing,
+)
 from .client import (
     PDUStatusError,
     ble_request,
@@ -157,10 +161,9 @@ def operation_lock(func: WrapFuncType) -> WrapFuncType:
     return cast(WrapFuncType, _async_operation_lock_wrap)
 
 
-
 def disconnect_on_missing_services(func: WrapFuncType) -> WrapFuncType:
     """Define a wrapper to disconnect on missing services and characteristics.
-    
+
     This must be placed after the retry_bluetooth_connection_error
     decorator.
     """
@@ -171,7 +174,10 @@ def disconnect_on_missing_services(func: WrapFuncType) -> WrapFuncType:
         try:
             return await func(self, *args, **kwargs)
         except (BleakServiceMissing, BleakCharacteristicMissing):
-            logger.warning("%s: Missing service or characteristic, disconnecting to force refetch of GATT services", self.name)
+            logger.warning(
+                "%s: Missing service or characteristic, disconnecting to force refetch of GATT services",
+                self.name,
+            )
             if self.client:
                 await self.client.disconnect()
             raise


### PR DESCRIPTION
Sometimes BlueZ fails to get all the services. If we disconnect and reconnect it resolves the problem.

This PR defines a wrapper that forces disconnect when the underlying code encounters a missing GATT service
or char

fixes #238

This only fixes the ones that fail to resolve sometimes unlikely #135 where they fail to resolve always.