### PR TITLE
Improve BLE pairing reliability, especially with esp32 proxies

### DIFF
--- a/aiohomekit/controller/ble/controller.py
+++ b/aiohomekit/controller/ble/controller.py
@@ -73,6 +73,21 @@ class BleController(AbstractController):
             return
 
         if pairing := self.pairings.get(data.id):
+            if (old_description := pairing.description) and len(
+                old_description.name
+            ) > len(data.name):
+                #
+                # If we have a pairing and the name is longer than the one we
+                # just received, we assume the name is more accurate and
+                # update it.
+                #
+                # SHORTENED LOCAL NAME
+                # The Shortened Local Name data type defines a shortened version
+                # of the Local Name data type. The Shortened Local Name data type
+                # shall not be used to advertise a name that is longer than the
+                # Local Name data type.
+                #
+                data.name = old_description.name
             pairing._async_description_update(data)
             pairing._async_ble_update(device, advertisement_data)
 

--- a/aiohomekit/controller/ble/pairing.py
+++ b/aiohomekit/controller/ble/pairing.py
@@ -882,20 +882,12 @@ class BlePairing(AbstractPairing):
         will have to un-pair it manually with a factory
         reset.
         """
-        if not self.accessories:
-            if self.description:
-                self._accessories_state = AccessoriesState(
-                    Accessories(), -1, self.broadcast_key
-                )
-                return self.description.name
-            parsed = await self.list_accessories_and_characteristics()
-        else:
-            parsed = self.accessories
-
-        accessory_info = parsed.aid(1).services.first(
-            service_type=ServicesTypes.ACCESSORY_INFORMATION
-        )
-        return accessory_info.value(CharacteristicsTypes.NAME, "")
+        if not self.accessories and self.description:
+            self._accessories_state = AccessoriesState(
+                Accessories(), -1, self.broadcast_key
+            )
+            return self.description.name
+        return await super().get_primary_name()
 
     async def _populate_char_values(self, config_changed: bool) -> None:
         """Populate the values of all characteristics."""

--- a/aiohomekit/controller/ble/pairing.py
+++ b/aiohomekit/controller/ble/pairing.py
@@ -898,6 +898,7 @@ class BlePairing(AbstractPairing):
             if (
                 not config_changed
                 and service.type == ServicesTypes.ACCESSORY_INFORMATION
+                and service.value(CharacteristicsTypes.NAME) is not None
             ):
                 continue
             for char in service.characteristics:

--- a/aiohomekit/controller/ble/pairing.py
+++ b/aiohomekit/controller/ble/pairing.py
@@ -898,7 +898,7 @@ class BlePairing(AbstractPairing):
             if (
                 not config_changed
                 and service.type == ServicesTypes.ACCESSORY_INFORMATION
-                and service.value(CharacteristicsTypes.NAME) is not None
+                and service.value(CharacteristicsTypes.NAME)
             ):
                 continue
             for char in service.characteristics:


### PR DESCRIPTION
Overrides the default implementation of get_primary_name
to get name from the advertisement if the
accessories are not available which happens
frequently with the ESPHome proxies because
they cannot currently connect right away again
after disconnecting.

We want to avoid raising there if possible
since this is called right after pairing
and if we raise the pairing will fail but
the device will still be paired and the user
will have to un-pair it manually with a factory
reset.

Also modifies the handle check to
handle no services being available yet.
