### PR TITLE
Use the same gatt write logic in _write_pdu as _read_signature

### DIFF
--- a/aiohomekit/controller/ble/client.py
+++ b/aiohomekit/controller/ble/client.py
@@ -96,7 +96,9 @@ async def _write_pdu(
         writes.append(data)
 
     for write in writes:
-        await client.write_gatt_char(handle, write, True)
+        await client.write_gatt_char(
+            handle, write, "write-without-response" not in handle.properties
+        )
 
 
 async def _read_pdu(


### PR DESCRIPTION
This speeds up writes a bit especially with the bluetooth proxies. 

No need to wait for a response if the device supports it because we are always waiting for the read response anyways.

