### PR TITLE
CoAP: Fix recovering from incorrect IPv6 address at start

### DIFF
--- a/aiohomekit/controller/coap/connection.py
+++ b/aiohomekit/controller/coap/connection.py
@@ -250,8 +250,6 @@ class CoAPHomeKitConnection:
     async def reconnect_soon(self):
         if not self.enc_ctx:
             return
-        description = self.owner.description
-        self.address = f"[{description.address}]:{description.port}"
         await self.enc_ctx.coap_ctx.shutdown()
         self.enc_ctx = None
         # XXX can't .connect here w/o pairing_data

--- a/aiohomekit/controller/coap/pairing.py
+++ b/aiohomekit/controller/coap/pairing.py
@@ -16,9 +16,10 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Iterable
 from datetime import timedelta
 import logging
-from typing import Any, Iterable
+from typing import Any
 
 from aiohomekit.controller.abstract import AbstractController, AbstractPairingData
 from aiohomekit.exceptions import AccessoryDisconnectedError
@@ -49,6 +50,8 @@ class CoAPPairing(ZeroconfPairing):
 
     def _async_endpoint_changed(self) -> None:
         """The IP/Port has changed, so close connection if active then reconnect."""
+        description = self.owner.description
+        self.connection.address = f"[{description.address}]:{description.port}"
         async_create_task(self.connection.reconnect_soon())
 
     @property

--- a/aiohomekit/controller/ip/pairing.py
+++ b/aiohomekit/controller/ip/pairing.py
@@ -16,11 +16,12 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Iterable
 from datetime import timedelta
 from itertools import groupby
 import logging
 from operator import itemgetter
-from typing import Any, Iterable
+from typing import Any
 
 from aiohomekit.controller.abstract import AbstractController, AbstractPairingData
 from aiohomekit.exceptions import (


### PR DESCRIPTION
We only set the updated address when there was an encryption context. That meant we couldn't fix the IP if it was wrong at startup.

Fixes: https://community.home-assistant.io/t/homekit-accessory-protocol-hap-over-coap-udp-was-nanoleaf-essentials-bulb-via-thread-coap/335167/311?u=jc2k.