### PR TITLE
Revert "Speed up BLE pair verify resume"

### DIFF
--- a/aiohomekit/controller/ble/client.py
+++ b/aiohomekit/controller/ble/client.py
@@ -222,12 +222,9 @@ async def drive_pairing_state_machine(
     client: AIOHomeKitBleakClient,
     characteristic: str,
     state_machine: Generator[tuple[list[tuple[TLV, bytes]], list[TLV]], Any, Any],
-    characteristic_iid: int | None = None,
 ) -> Any:
     char = await client.get_characteristic(ServicesTypes.PAIRING, characteristic)
-    # Reading the descriptor to get the iid is slow. If we already know the iid
-    # then we can skip this step which saves a lot of time.
-    iid = characteristic_iid or await client.get_characteristic_iid(char)
+    iid = await client.get_characteristic_iid(char)
 
     request, expected = state_machine.send(None)
     while True:

--- a/aiohomekit/controller/ble/pairing.py
+++ b/aiohomekit/controller/ble/pairing.py
@@ -569,30 +569,11 @@ class BlePairing(AbstractPairing):
 
     async def _async_pair_verify(self) -> None:
         async with self._ble_request_lock:
-            # There is only one pair verify characteristic
-            # per device so we can just use the first one
-            # and avoid having to request the iid which speeds
-            # up the pairing resume process
-            try:
-                pair_verify_char = (
-                    self.accessories.aid(BLE_AID)
-                    .services.first(service_type=ServicesTypes.PAIRING)
-                    .characteristics.first(
-                        char_types=[CharacteristicsTypes.PAIR_VERIFY]
-                    )
-                )
-            except StopIteration:
-                # If we don't have a pair verify characteristic yet
-                # it means we haven't fetched the services yet
-                pair_verify_char = None
-
             session_id, derive = await drive_pairing_state_machine(
                 self.client,
                 CharacteristicsTypes.PAIR_VERIFY,
                 get_session_keys(self.pairing_data, self._session_id, self._derive),
-                pair_verify_char.iid if pair_verify_char else None,
             )
-
             self._encryption_key = EncryptionKey(
                 derive(b"Control-Salt", b"Control-Write-Encryption-Key")
             )


### PR DESCRIPTION
Reverts Jc2k/aiohomekit#261

This seems to increase the risk of `Operation failed with ATT error: 0x0e (Unlikely Error)` happening quite a bit with bluez.  Its likely making it to quick for the bluez to keep up and ending up disconnected.

I think we are stuck with a revert for now.  A bit slower and reliable is better than unexpected disconnects.  Its also less of a concern after #267 anyways.

