### PR TITLE
Pad short uuid with 0's

### DIFF
--- a/aiohomekit/uuid.py
+++ b/aiohomekit/uuid.py
@@ -55,6 +55,6 @@ def normalize_uuid(value: str) -> str:
     # Handle cases like 34AB8811AC7F4340BAC3FD6A85F9943B
     # Reject the rest
     try:
-        return str(UUID(value)).upper()
+        return str(UUID(value.zfill(32))).upper()
     except ValueError:
         raise ValueError(f"{value} doesn't look like a valid UUID or short UUID")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -44,6 +44,13 @@ def test_normalize_uuid():
     )
 
 
+def test_normalize_uuid_coap_short():
+    assert (
+        normalize_uuid("45E5011ECB4000A80FF2603DE")
+        == "00000004-5E50-11EC-B400-0A80FF2603DE"
+    )
+
+
 def test_normalize_invalid_uuid():
     with pytest.raises(Exception):
         normalize_uuid("NOT_A_VALID_UUID")


### PR DESCRIPTION
In CoAP we are seeing squished UUID's like `45E5011ECB4000A80FF2603DE`. These need padding to 32 chars with leading `0` before normalising.

E.g. `45E5011ECB4000A80FF2603DE` should become `00000004-5E50-11EC-B400-0A80FF2603DE`.

Via https://community.home-assistant.io/t/homekit-accessory-protocol-hap-over-coap-udp-was-nanoleaf-essentials-bulb-via-thread-coap/335167/346?u=jc2k
