### PR TITLE
Fix service build_update typing

### DIFF
--- a/aiohomekit/model/services/service.py
+++ b/aiohomekit/model/services/service.py
@@ -123,7 +123,7 @@ class Service:
     def add_linked_service(self, service: Service) -> None:
         self.linked.append(service)
 
-    def build_update(self, payload: dict[str, Any]) -> list[int, int, Any]:
+    def build_update(self, payload: dict[str, Any]) -> list[tuple[int, int, Any]]:
         """
         Given a payload in the form of {CHAR_TYPE: value}, render in a form suitable to pass
         to put_characteristics using aid and iid.


### PR DESCRIPTION
The return type for `Service.build_update` should be a list of tuples.