### PR TITLE
Add vendor extension for Airversa sleep mode

### DIFF
--- a/aiohomekit/model/characteristics/characteristic_types.py
+++ b/aiohomekit/model/characteristics/characteristic_types.py
@@ -380,3 +380,6 @@ class CharacteristicsTypes:
 
     # https://github.com/home-assistant/core/issues/73360 (r/o, dB)
     VENDOR_NETATMO_NOISE = "B3BBFABC-D78C-5B8D-948C-5DAC1EE2CDE5"
+
+    # r/w, int - 1 for on, 0 for off
+    VENDOR_AIRVERSA_SLEEP_MODE = "00000006-5E50-11EC-B400-0A80FF2603DE"


### PR DESCRIPTION
This adds a constant for the Airversa characteristic for sleep mode. If you can point me to how I can log characteristic changes I wouldn't mind attempting to figure out what the other vendor specific keys do.

For PR verification purposes, here is the definition of this value from the device diagnostics:

```
              {
                "type": "00000006-5E50-11EC-B400-0A80FF2603DE",
                "iid": 32842,
                "perms": [
                  "pr",
                  "pw",
                  "ev"
                ],
                "format": "int",
                "value": 0,
                "minValue": 0,
                "maxValue": 1
              },
```