### PR TITLE
Handling response as dict and list in case of failure in IpPairing#pu…

### DIFF
--- a/aiohomekit/controller/ip/pairing.py
+++ b/aiohomekit/controller/ip/pairing.py
@@ -299,9 +299,7 @@ class IpPairing(ZeroconfPairing):
             # If there is a response it means something failed so
             # we need to remove the listener update for the failed
             # characteristics.
-            if isinstance(response, dict) and "characteristics" in response:
-                response = response["characteristics"]
-            for characteristic in response:
+            for characteristic in response["characteristics"]:
                 aid, iid = characteristic["aid"], characteristic["iid"]
                 key = (aid, iid)
                 status = characteristic["status"]

--- a/aiohomekit/controller/ip/pairing.py
+++ b/aiohomekit/controller/ip/pairing.py
@@ -304,8 +304,8 @@ class IpPairing(ZeroconfPairing):
                 key = (aid, iid)
                 status = characteristic["status"]
                 status_code = to_status_code(status).description
-                if status_code != HapStatusCode.SUCCESS and key in listener_update:
-                    listener_update.pop(key)
+                if status_code != HapStatusCode.SUCCESS:
+                    listener_update.pop(key, None)
                 response_status[key] = {"status": status, "description": status_code}
 
         if listener_update:

--- a/aiohomekit/controller/ip/pairing.py
+++ b/aiohomekit/controller/ip/pairing.py
@@ -299,6 +299,8 @@ class IpPairing(ZeroconfPairing):
             # If there is a response it means something failed so
             # we need to remove the listener update for the failed
             # characteristics.
+            if isinstance(response, dict) and "characteristics" in response:
+                response = response["characteristics"]
             for characteristic in response:
                 aid, iid = characteristic["aid"], characteristic["iid"]
                 key = (aid, iid)

--- a/aiohomekit/controller/ip/pairing.py
+++ b/aiohomekit/controller/ip/pairing.py
@@ -304,7 +304,7 @@ class IpPairing(ZeroconfPairing):
                 key = (aid, iid)
                 status = characteristic["status"]
                 status_code = to_status_code(status).description
-                if status_code != HapStatusCode.SUCCESS:
+                if status_code != HapStatusCode.SUCCESS and key in listener_update:
                     listener_update.pop(key)
                 response_status[key] = {"status": status, "description": status_code}
 

--- a/tests/test_ip_pairing.py
+++ b/tests/test_ip_pairing.py
@@ -327,3 +327,12 @@ async def test_transport_property(pairing: IpPairing):
 
 async def test_polling_property(pairing: IpPairing):
     assert pairing.poll_interval == timedelta(seconds=60)
+
+
+async def test_put_characteristics_invalid_value(pairing: IpPairing):
+    aid, iid = (1, 2)
+    characteristics = [(aid, iid, 100)]
+    status_code = await pairing.put_characteristics(characteristics)
+    assert status_code is not None
+    assert status_code[(aid, iid)] is not None
+    assert status_code[(aid, iid)]["status"] == HapStatusCode.INVALID_VALUE.value


### PR DESCRIPTION
I believe it solves the issue found over here:
https://github.com/home-assistant/core/issues/85400#issuecomment-1379381464

response for our shutter roller seems to be a single key dict as it can be seen in the log attached. The change fixes the errors I'm getting. There might be a different cause on this, but I can't keep track of all that.

[home-assistant_2023-01-12T11-12-01.387Z.log](https://github.com/Jc2k/aiohomekit/files/10401686/home-assistant_2023-01-12T11-12-01.387Z.log)
