### PR TITLE
Avoid linear searches to get services by service_type

### DIFF
--- a/aiohomekit/model/__init__.py
+++ b/aiohomekit/model/__init__.py
@@ -64,6 +64,7 @@ class Services:
     def __init__(self):
         self._services: list[Service] = []
         self._iid_to_service: dict[int, Service] = {}
+        self._type_to_service: dict[str, Service] = {}
 
     def __iter__(self) -> Iterator[Service]:
         return iter(self._services)
@@ -123,6 +124,14 @@ class Services:
         parent_service: Service = None,
         child_service: Service = None,
     ) -> Service:
+        if (
+            service_type is not None
+            and characteristics is None
+            and parent_service is None
+            and child_service is None
+        ):
+            return self._type_to_service.get(normalize_uuid(service_type))
+
         try:
             return next(
                 self.filter(
@@ -138,6 +147,8 @@ class Services:
     def append(self, service: Service):
         self._services.append(service)
         self._iid_to_service[service.iid] = service
+        if service.type not in self._type_to_service:
+            self._type_to_service[service.type] = service
 
 
 class Characteristics:

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -158,6 +158,18 @@ def test_get_by_vendor_characteristic_types():
     assert char.value == spray_level
 
 
+def test_get_by_service_type_is_normalized():
+    """Test we can get a service by a normalized service type."""
+    a = Accessories.from_file("tests/fixtures/vocolinc_flowerbud.json").aid(1)
+
+    service = a.services.first(
+        service_type=ServicesTypes.HUMIDIFIER_DEHUMIDIFIER.lower(),
+    )
+
+    found = service.has(CharacteristicsTypes.VENDOR_VOCOLINC_HUMIDIFIER_SPRAY_LEVEL)
+    assert found is True
+
+
 def test_get_by_linked():
     name = "Hue dimmer switch button 3"
     a = Accessories.from_file("tests/fixtures/hue_bridge.json").aid(6623462389072572)


### PR DESCRIPTION
Since most lookups are by service_type we now store them in a dict under the hood to avoid linear searches

fixes #276