### PR TITLE
BLE should use hkid at API boundary, not MAC

### DIFF
--- a/aiohomekit/controller/abstract.py
+++ b/aiohomekit/controller/abstract.py
@@ -81,6 +81,7 @@ class AbstractPairing(metaclass=ABCMeta):
         self._shutdown = False
 
         self.id = pairing_data["AccessoryPairingID"]
+        print("Pairing: %s: %r", self.id, pairing_data)
         self._pairing_data = pairing_data
         self._load_accessories_from_cache()
 

--- a/aiohomekit/controller/abstract.py
+++ b/aiohomekit/controller/abstract.py
@@ -81,7 +81,6 @@ class AbstractPairing(metaclass=ABCMeta):
         self._shutdown = False
 
         self.id = pairing_data["AccessoryPairingID"]
-        print("Pairing: %s: %r", self.id, pairing_data)
         self._pairing_data = pairing_data
         self._load_accessories_from_cache()
 

--- a/aiohomekit/controller/ble/controller.py
+++ b/aiohomekit/controller/ble/controller.py
@@ -41,7 +41,6 @@ class BleController(AbstractController):
         super().__init__(char_cache=char_cache)
         self._scanner = bleak_scanner_instance
         self._ble_futures: dict[str, list[asyncio.Future[BLEDevice]]] = {}
-        self._ble_futures_by_id: dict[str, list[asyncio.Future[BLEDevice]]] = {}
 
     def _device_detected(
         self, device: BLEDevice, advertisement_data: AdvertisementData
@@ -94,16 +93,9 @@ class BleController(AbstractController):
             pairing._async_description_update(data)
             pairing._async_ble_update(device, advertisement_data)
 
-        if futures := self._ble_futures_by_id.get(data.id):
+        if futures := self._ble_futures.get(data.id):
             discovery = BleDiscovery(self, device, data, advertisement_data)
             logger.debug("BLE device for %s found, fulfilling futures", data.id)
-            for future in futures:
-                future.set_result(discovery)
-            futures.clear()
-
-        if futures := self._ble_futures.get(data.address):
-            discovery = BleDiscovery(self, device, data, advertisement_data)
-            logger.debug("BLE device for %s found, fulfilling futures", data.address)
             for future in futures:
                 future.set_result(discovery)
             futures.clear()
@@ -154,7 +146,6 @@ class BleController(AbstractController):
             timeout,
         )
         future = asyncio.Future()
-        self._ble_futures_by_id.setdefault(device_id, []).append(future)
         try:
             async with asyncio_timeout(timeout):
                 return await future
@@ -166,49 +157,16 @@ class BleController(AbstractController):
             )
             return None
         finally:
-            if device_id not in self._ble_futures_by_id:
+            if device_id not in self._ble_futures:
                 return
-            if future in self._ble_futures_by_id[device_id]:
-                self._ble_futures_by_id[device_id].remove(future)
-            if not self._ble_futures_by_id[device_id]:
-                del self._ble_futures_by_id[device_id]
+            if future in self._ble_futures[device_id]:
+                self._ble_futures[device_id].remove(future)
+            if not self._ble_futures[device_id]:
+                del self._ble_futures[device_id]
 
     async def async_discover(self) -> AsyncIterable[BleDiscovery]:
         for device in self.discoveries.values():
             yield device
-
-    async def async_get_discovery(
-        self, address: str, timeout: int
-    ) -> BleDiscovery | None:
-        """Get a discovery by address."""
-        if discovery := self.discoveries.get(address):
-            logger.debug("Discovery for %s already found", address)
-            return discovery
-
-        logger.debug(
-            "Discovery for address %s not found, waiting for advertisement with timeout: %s",
-            address,
-            timeout,
-        )
-        future = asyncio.Future()
-        self._ble_futures.setdefault(address, []).append(future)
-        try:
-            async with asyncio_timeout(timeout):
-                return await future
-        except asyncio.TimeoutError:
-            logger.debug(
-                "Timed out after %s waiting for discovery with address %s",
-                timeout,
-                address,
-            )
-            return None
-        finally:
-            if address not in self._ble_futures:
-                return
-            if future in self._ble_futures[address]:
-                self._ble_futures[address].remove(future)
-            if not self._ble_futures[address]:
-                del self._ble_futures[address]
 
     def load_pairing(
         self, alias: str, pairing_data: AbstractPairingData

--- a/aiohomekit/controller/ble/pairing.py
+++ b/aiohomekit/controller/ble/pairing.py
@@ -475,8 +475,8 @@ class BlePairing(AbstractPairing):
             if self._shutdown or (self.client and self.client.is_connected):
                 return False
             if not self.device and (
-                discovery := await self.controller.async_get_discovery(
-                    self.address, DISCOVER_TIMEOUT
+                discovery := await self.controller.async_find(
+                    self.id, DISCOVER_TIMEOUT
                 )
             ):
                 self.device = discovery.device
@@ -484,7 +484,7 @@ class BlePairing(AbstractPairing):
                 self.description = discovery.description
             elif not self.device:
                 raise AccessoryNotFoundError(
-                    f"{self.name}: Could not find {self.address}"
+                    f"{self.name}: Could not find {self.id}"
                 )
             self.client = await establish_connection(
                 self.device,

--- a/aiohomekit/controller/ble/pairing.py
+++ b/aiohomekit/controller/ble/pairing.py
@@ -475,17 +475,13 @@ class BlePairing(AbstractPairing):
             if self._shutdown or (self.client and self.client.is_connected):
                 return False
             if not self.device and (
-                discovery := await self.controller.async_find(
-                    self.id, DISCOVER_TIMEOUT
-                )
+                discovery := await self.controller.async_find(self.id, DISCOVER_TIMEOUT)
             ):
                 self.device = discovery.device
                 self.ble_advertisement = discovery.ble_advertisement
                 self.description = discovery.description
             elif not self.device:
-                raise AccessoryNotFoundError(
-                    f"{self.name}: Could not find {self.id}"
-                )
+                raise AccessoryNotFoundError(f"{self.name}: Could not find {self.id}")
             self.client = await establish_connection(
                 self.device,
                 self.name,


### PR DESCRIPTION
So that we can merge CoAP and BLE discoveries for the same device and so that we can migrate a BLE pairing to a CoAP pairing we should use the HAP device ID (hkid) as the key in our API, not the BLE mac address. This is needed for #148.

This PR doesn't really address the root cause, it just removes some duplicated code that incorrectly looks in `self.discoveries` for a mac address, that would always fail. So i think this PR could go out independently of the HA changes.

In addition to this PR, HA needs the following patches:

```
await self.async_set_unique_id(discovery_info.address)
self._abort_if_unique_id_configured()
```

This needs to move after parsing the advertisement and use device.id instead. It should call normalized_hkid.

It also needs a migration to fix `unique_id` on any existing config entries. Mercifully, it looks like the entity unique ids are correct, and it looks like the device registry is also correct. This needs additional validation.