### PR TITLE
Bump zeroconf to 0.54.0 to fix handling server name changes

### DIFF
--- a/aiohomekit/zeroconf.py
+++ b/aiohomekit/zeroconf.py
@@ -21,7 +21,6 @@ from abc import abstractmethod
 import asyncio
 from collections.abc import AsyncIterable
 from dataclasses import dataclass
-from ipaddress import ip_address
 import logging
 
 import async_timeout

--- a/aiohomekit/zeroconf.py
+++ b/aiohomekit/zeroconf.py
@@ -28,10 +28,10 @@ import async_timeout
 from zeroconf import (
     BadTypeInNameException,
     DNSPointer,
+    IPVersion,
     ServiceListener,
     ServiceStateChange,
     Zeroconf,
-    IPVersion,
 )
 from zeroconf.asyncio import AsyncServiceBrowser, AsyncServiceInfo, AsyncZeroconf
 

--- a/aiohomekit/zeroconf.py
+++ b/aiohomekit/zeroconf.py
@@ -31,6 +31,7 @@ from zeroconf import (
     ServiceListener,
     ServiceStateChange,
     Zeroconf,
+    IPVersion,
 )
 from zeroconf.asyncio import AsyncServiceBrowser, AsyncServiceInfo, AsyncZeroconf
 
@@ -57,33 +58,8 @@ _TIMEOUT_MS = 3000
 logger = logging.getLogger(__name__)
 
 
-def _first_non_link_local_address(
-    addresses: list[bytes] | list[str],
-) -> str | None:
-    """Return the first ipv6 or non-link local ipv4 address, preferring IPv4."""
-    for address in addresses:
-        ip_addr = ip_address(address)
-        if (
-            not ip_addr.is_link_local
-            and not ip_addr.is_unspecified
-            and ip_addr.version == 4
-        ):
-            return str(ip_addr)
-    # If we didn't find a good IPv4 address, check for IPv6 addresses.
-    for address in addresses:
-        ip_addr = ip_address(address)
-        if (
-            not ip_addr.is_link_local
-            and not ip_addr.is_unspecified
-            and ip_addr.version == 6
-        ):
-            return str(ip_addr)
-    return None
-
-
 @dataclass
 class HomeKitService:
-
     name: str
     id: str
     model: str
@@ -102,8 +78,25 @@ class HomeKitService:
 
     @classmethod
     def from_service_info(cls, service: AsyncServiceInfo) -> HomeKitService:
-        if not (addresses := service.parsed_addresses()):
+        if not (addresses := service.ip_addresses_by_version(IPVersion.All)):
             raise ValueError("Invalid HomeKit Zeroconf record: Missing address")
+
+        address: str | None = None
+        #
+        # Zeroconf addresses are guaranteed to be returned in LIFO (last in, first out)
+        # order with IPv4 addresses first and IPv6 addresses second.
+        #
+        # This means the first address will always be the most recently added
+        # address of the given IP version.
+        #
+        for ip_addr in addresses:
+            if not ip_addr.is_link_local and not ip_addr.is_unspecified:
+                address = str(ip_addr)
+                break
+        if not address:
+            raise ValueError(
+                "Invalid HomeKit Zeroconf record: Missing non-link-local or unspecified address"
+            )
 
         props: dict[str, str] = {
             k.decode("utf-8").lower(): v.decode("utf-8")
@@ -124,8 +117,8 @@ class HomeKitService:
             category=Categories(int(props.get("ci", 1))),
             protocol_version=props.get("pv", "1.0"),
             type=service.type,
-            address=_first_non_link_local_address(addresses),
-            addresses=addresses,
+            address=address,
+            addresses=[str(ip_addr) for ip_addr in addresses],
             port=service.port,
         )
 
@@ -155,7 +148,6 @@ def find_brower_for_hap_type(azc: AsyncZeroconf, hap_type: str) -> AsyncServiceB
 
 
 class ZeroconfDiscovery(AbstractDiscovery):
-
     description: HomeKitService
 
     def __init__(self, description: HomeKitService):

--- a/poetry.lock
+++ b/poetry.lock
@@ -602,6 +602,8 @@ files = [
     {file = "cryptography-39.0.1-cp36-abi3-win32.whl", hash = "sha256:fe913f20024eb2cb2f323e42a64bdf2911bb9738a15dba7d3cce48151034e3a8"},
     {file = "cryptography-39.0.1-cp36-abi3-win_amd64.whl", hash = "sha256:ced4e447ae29ca194449a3f1ce132ded8fcab06971ef5f618605aacaa612beac"},
     {file = "cryptography-39.0.1-pp38-pypy38_pp73-macosx_10_12_x86_64.whl", hash = "sha256:807ce09d4434881ca3a7594733669bd834f5b2c6d5c7e36f8c00f691887042ad"},
+    {file = "cryptography-39.0.1-pp38-pypy38_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:c5caeb8188c24888c90b5108a441c106f7faa4c4c075a2bcae438c6e8ca73cef"},
+    {file = "cryptography-39.0.1-pp38-pypy38_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:4789d1e3e257965e960232345002262ede4d094d1a19f4d3b52e48d4d8f3b885"},
     {file = "cryptography-39.0.1-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:96f1157a7c08b5b189b16b47bc9db2332269d6680a196341bf30046330d15388"},
     {file = "cryptography-39.0.1-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:e422abdec8b5fa8462aa016786680720d78bdce7a30c652b7fadf83a4ba35336"},
     {file = "cryptography-39.0.1-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:b0afd054cd42f3d213bf82c629efb1ee5f22eba35bf0eec88ea9ea7304f511a2"},
@@ -1664,21 +1666,21 @@ multidict = ">=4.0"
 
 [[package]]
 name = "zeroconf"
-version = "0.39.4"
-description = "Pure Python Multicast DNS Service Discovery Library (Bonjour/Avahi compatible)"
+version = "0.54.0"
+description = "A pure python implementation of multicast DNS service discovery"
 category = "main"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.7,<4.0"
 files = [
-    {file = "zeroconf-0.39.4-py3-none-any.whl", hash = "sha256:d60eae9e9c99d1a168ce9ff9de7e7398c23754a0c2004ded230f8d529c5260a0"},
-    {file = "zeroconf-0.39.4.tar.gz", hash = "sha256:701e4d697f89fe952aa9c13a512ed6bf472dcf4f0a6d275e71085604b3882295"},
+    {file = "zeroconf-0.54.0-cp310-cp310-manylinux_2_31_x86_64.whl", hash = "sha256:8372e09305e0185f782c71559b97e2f1a00549a1766ae3dfeb6c00fc15c9b2d4"},
+    {file = "zeroconf-0.54.0.tar.gz", hash = "sha256:635f764abc8ebf2c28529d60f75c27ca777fbcebf3c9cd611339cae0e4859312"},
 ]
 
 [package.dependencies]
-async-timeout = ">=4.0.1"
+async-timeout = {version = ">=3.0.0", markers = "python_version < \"3.11\""}
 ifaddr = ">=0.1.7"
 
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "c94305ea0f85533d26669cc4158d7d4e19c43102ee2a6671f8737090125e964b"
+content-hash = "8eb7b0ac48bf7c0e16e071df610f0dca29295f05d9c42b01db04ffb22b82c7b5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ include = ["aiohomekit/py.typed"]
 [tool.poetry.dependencies]
 python = "^3.9"
 cryptography = ">=2.9.2"
-zeroconf = ">=0.32.0"
+zeroconf = ">=0.54.0"
 commentjson = "^0.9.0"
 aiocoap = ">=0.4.5"
 bleak = ">=0.19.0"


### PR DESCRIPTION
Removes the need for _first_non_link_local_address since zeroconf now guarantees LIFO order for addresses