### PR TITLE
Fix content-type on python 3.11

### DIFF
--- a/aiohomekit/controller/ip/connection.py
+++ b/aiohomekit/controller/ip/connection.py
@@ -322,7 +322,10 @@ class HomeKitConnection:
         return await self.request(
             method="PUT",
             target=target,
-            headers=[("Content-Length", len(body)), ("Content-Type", content_type)],
+            headers=[
+                ("Content-Length", len(body)),
+                ("Content-Type", content_type.value),
+            ],
             body=body,
         )
 
@@ -362,7 +365,10 @@ class HomeKitConnection:
         return await self.request(
             method="POST",
             target=target,
-            headers=[("Content-Length", len(body)), ("Content-Type", content_type)],
+            headers=[
+                ("Content-Length", len(body)),
+                ("Content-Type", content_type.value),
+            ],
             body=body,
         )
 

--- a/aiohomekit/http/__init__.py
+++ b/aiohomekit/http/__init__.py
@@ -19,7 +19,7 @@ import enum
 __all__ = ["HttpContentTypes", "HttpStatusCodes"]
 
 
-class HttpContentTypes(str, enum.Enum):
+class HttpContentTypes(enum.Enum):
     """
     Collection of HTTP content types as used in HTTP headers
     """


### PR DESCRIPTION
Should fix

```
2023-06-07 23:08:07.990 DEBUG (MainThread) [aiohomekit.controller.ip.connection] 192.168.178.149: raw request: b'POST /pair-verify HTTP/1.1\r\nHost: 192.168.178.149\r\nContent-Length: 37\r\nContent-Type: HttpContentTypes.TLV\r\n\r\n\x06\x01\x01\x03 \xa1[\xae\xe0J\xcc\xc5{\xd2f\xb8\xfd\xfd\x11\xdb\x1bP\x8a\x93\xe8\x01\xc3\xf8\x05w\xe4\xe7\xbd9\x8c\x08E'
```