### PR TITLE
Fix ble controller discovery where old name is None

### DIFF
--- a/aiohomekit/controller/ble/controller.py
+++ b/aiohomekit/controller/ble/controller.py
@@ -78,9 +78,8 @@ class BleController(AbstractController):
             return
 
         if old_discovery := self.discoveries.get(data.id):
-            if (
-                (old_name := old_discovery.description.name)
-                and not (name := data.name)
+            if (old_name := old_discovery.description.name) and (
+                not (name := data.name)
                 or (
                     old_name != old_discovery.device.address
                     and len(old_name) > len(name)

--- a/tests/test_controller_ble.py
+++ b/tests/test_controller_ble.py
@@ -87,6 +87,8 @@ def test_discovery_with_none_name(
             76: b"\x061\x00\x80\xe7\x14j74\x06\x00\x9f!\x04\x02<\xb9\xeb\x0e"
         },
     )
+    ble_controller._device_detected(ble_device, adv)
+    assert "80:e7:14:6a:37:34" in ble_controller.discoveries
     ble_controller._device_detected(ble_device_with_short_name, adv)
     assert "80:e7:14:6a:37:34" in ble_controller.discoveries
     assert (


### PR DESCRIPTION
The fix in #298 was not sufficient