### PR TITLE
Reduce memory churn and copy while decoding large payload

### DIFF
--- a/aiohomekit/controller/ble/client.py
+++ b/aiohomekit/controller/ble/client.py
@@ -125,8 +125,6 @@ async def _write_pdu(
             logger.debug("Queuing fragment for write: %s", data)
         if encryption_key:
             data = encryption_key.encrypt(bytes(data))
-            if debug:
-                logger.debug("Encrypted fragment: %s", data)
         writes.append(data)
 
     response = "write-without-response" not in handle.properties
@@ -150,7 +148,9 @@ async def _read_pdu(
         except DecryptionError:
             raise EncryptionError("Decryption failed")
 
-    logger.debug("Read fragment: %s", data)
+    debug = logger.isEnabledFor(logging.DEBUG)
+    if debug:
+        logger.debug("Read fragment: %s", data)
 
     # Validate the PDU header
     status, expected_length, data = decode_pdu(tid, data)
@@ -168,7 +168,8 @@ async def _read_pdu(
                 next = decryption_key.decrypt(bytes(next))
             except DecryptionError:
                 raise EncryptionError("Decryption failed")
-        logger.debug("Read fragment: %s", next)
+        if debug:
+            logger.debug("Read fragment: %s", next)
 
         data += decode_pdu_continuation(tid, next)
 

--- a/aiohomekit/controller/ble/client.py
+++ b/aiohomekit/controller/ble/client.py
@@ -214,7 +214,7 @@ async def _pairing_char_write(
 
     for _ in range(MAX_REASSEMBLY):
         data = await char_write(client, None, None, handle, iid, next_write)
-        decoded = dict(TLV.decode_bytearray(data))
+        decoded = dict(TLV.decode_bytearray(bytearray(data)))
         if TLV.kTLVType_FragmentLast in decoded:
             logger.debug("%s: Reassembling final fragment", client.address)
             buffer.extend(decoded[TLV.kTLVType_FragmentLast])

--- a/aiohomekit/controller/ble/client.py
+++ b/aiohomekit/controller/ble/client.py
@@ -122,7 +122,7 @@ async def _write_pdu(
     for data in encode_pdu(opcode, tid, iid, data, fragment_size):
         logger.debug("Queuing fragment for write: %s", data)
         if encryption_key:
-            data = encryption_key.encrypt(data)
+            data = encryption_key.encrypt(bytes(data))
         writes.append(data)
 
     for write in writes:

--- a/aiohomekit/controller/ble/client.py
+++ b/aiohomekit/controller/ble/client.py
@@ -23,7 +23,7 @@ from typing import Any, Callable, TypeVar, cast
 from bleak import BleakClient
 from bleak.backends.characteristic import BleakGATTCharacteristic
 
-from aiohomekit.controller.ble.key import DecryptionKey, EncryptionKey, DecryptionError
+from aiohomekit.controller.ble.key import DecryptionError, DecryptionKey, EncryptionKey
 from aiohomekit.exceptions import EncryptionError
 from aiohomekit.model.services import ServicesTypes
 from aiohomekit.pdu import (

--- a/aiohomekit/controller/ble/key.py
+++ b/aiohomekit/controller/ble/key.py
@@ -21,9 +21,8 @@ from aiohomekit.crypto.chacha20poly1305 import (
     ChaCha20Poly1305Decryptor,
     ChaCha20Poly1305Encryptor,
     ChaCha20Poly1305PartialTag,
-    DecryptionError,  # noqa: F401
 )
-
+from aiohomekit.crypto.chacha20poly1305 import DecryptionError  # noqa: F401
 
 class EncryptionKey:
     def __init__(self, key: bytes):

--- a/aiohomekit/controller/ble/key.py
+++ b/aiohomekit/controller/ble/key.py
@@ -24,6 +24,7 @@ from aiohomekit.crypto.chacha20poly1305 import (
 )
 from aiohomekit.crypto.chacha20poly1305 import DecryptionError  # noqa: F401
 
+
 class EncryptionKey:
     def __init__(self, key: bytes):
         self.key = ChaCha20Poly1305Encryptor(key)

--- a/aiohomekit/controller/ble/key.py
+++ b/aiohomekit/controller/ble/key.py
@@ -20,6 +20,7 @@ from aiohomekit.crypto.chacha20poly1305 import (
     ChaCha20Poly1305Decryptor,
     ChaCha20Poly1305Encryptor,
     ChaCha20Poly1305PartialTag,
+    PACK_NONCE,
 )
 
 
@@ -28,9 +29,8 @@ class EncryptionKey:
         self.key = ChaCha20Poly1305Encryptor(key)
         self.counter = 0
 
-    def encrypt(self, data: bytes | bytearray):
-        cnt_bytes = self.counter.to_bytes(8, byteorder="little")
-        data = self.key.encrypt(b"", cnt_bytes, bytes([0, 0, 0, 0]), data)
+    def encrypt(self, data: bytes) -> bytes:
+        data = self.key.encrypt(b"", PACK_NONCE(self.counter), data)
         self.counter += 1
         return data
 
@@ -40,10 +40,8 @@ class DecryptionKey:
         self.key = ChaCha20Poly1305Decryptor(key)
         self.counter = 0
 
-    def decrypt(self, data: bytes | bytearray):
-        counter = self.counter.to_bytes(8, byteorder="little")
-
-        data = self.key.decrypt(b"", counter, bytes([0, 0, 0, 0]), data)
+    def decrypt(self, data: bytes) -> bytes:
+        data = self.key.decrypt(b"", PACK_NONCE(self.counter), data)
         self.counter += 1
         return data
 

--- a/aiohomekit/controller/ble/key.py
+++ b/aiohomekit/controller/ble/key.py
@@ -17,10 +17,10 @@
 from __future__ import annotations
 
 from aiohomekit.crypto.chacha20poly1305 import (
+    PACK_NONCE,
     ChaCha20Poly1305Decryptor,
     ChaCha20Poly1305Encryptor,
     ChaCha20Poly1305PartialTag,
-    PACK_NONCE,
 )
 
 

--- a/aiohomekit/controller/ble/key.py
+++ b/aiohomekit/controller/ble/key.py
@@ -21,6 +21,7 @@ from aiohomekit.crypto.chacha20poly1305 import (
     ChaCha20Poly1305Decryptor,
     ChaCha20Poly1305Encryptor,
     ChaCha20Poly1305PartialTag,
+    DecryptionError,  # noqa: F401
 )
 
 

--- a/aiohomekit/controller/ble/key.py
+++ b/aiohomekit/controller/ble/key.py
@@ -54,5 +54,4 @@ class BroadcastDecryptionKey:
     def decrypt(
         self, data: bytes | bytearray, gsn: int, advertising_identifier: bytes
     ) -> bytes | bool:
-        gsn_bytes = b"\x00\x00\x00\x00" + gsn.to_bytes(8, byteorder="little")
-        return self.key.open(gsn_bytes, data, advertising_identifier)
+        return self.key.open(PACK_NONCE(gsn), data, advertising_identifier)

--- a/aiohomekit/controller/ble/pairing.py
+++ b/aiohomekit/controller/ble/pairing.py
@@ -34,6 +34,7 @@ from bleak_retry_connector import (
     BLEAK_RETRY_EXCEPTIONS as BLEAK_EXCEPTIONS,
     retry_bluetooth_connection_error,
 )
+from .client import disconnect_on_missing_services
 
 from aiohomekit.exceptions import (
     AccessoryDisconnectedError,
@@ -190,31 +191,6 @@ def operation_lock(func: WrapFuncType) -> WrapFuncType:
 
     return cast(WrapFuncType, _async_operation_lock_wrap)
 
-
-def disconnect_on_missing_services(func: WrapFuncType) -> WrapFuncType:
-    """Define a wrapper to disconnect on missing services and characteristics.
-
-    This must be placed after the retry_bluetooth_connection_error
-    decorator.
-    """
-
-    async def _async_disconnect_on_missing_services_wrap(
-        self: BlePairing, *args: Any, **kwargs: Any
-    ) -> None:
-        try:
-            return await func(self, *args, **kwargs)
-        except (BleakServiceMissing, BleakCharacteristicMissing) as ex:
-            logger.warning(
-                "%s: Missing service or characteristic, disconnecting to force refetch of GATT services: %s",
-                self.name,
-                ex,
-            )
-            if self.client:
-                await self.client.clear_cache()
-                await self.client.disconnect()
-            raise
-
-    return cast(WrapFuncType, _async_disconnect_on_missing_services_wrap)
 
 
 def restore_connection_and_resume(func: WrapFuncType) -> WrapFuncType:
@@ -681,7 +657,7 @@ class BlePairing(AbstractPairing):
         for state_num in (
             start_state_num + 1,
             start_state_num,
-            *range(start_state_num + 2, start_state_num + 30),
+            *range(start_state_num + 2, start_state_num + 50),
         ):
             logger.debug(
                 "%s: Trying state_num %s for encrypted notification: %s",

--- a/aiohomekit/controller/ble/pairing.py
+++ b/aiohomekit/controller/ble/pairing.py
@@ -681,7 +681,7 @@ class BlePairing(AbstractPairing):
         for state_num in (
             start_state_num + 1,
             start_state_num,
-            *range(start_state_num + 2, start_state_num + 30),
+            *range(start_state_num + 2, start_state_num + 100),
         ):
             logger.debug(
                 "%s: Trying state_num %s for encrypted notification: %s",

--- a/aiohomekit/controller/ip/connection.py
+++ b/aiohomekit/controller/ip/connection.py
@@ -178,7 +178,7 @@ class SecureHomeKitProtocol(InsecureHomeKitProtocol):
 
             try:
                 decrypted = self.decryptor.decrypt(
-                    block_length_bytes,
+                    bytes(block_length_bytes),
                     PACK_NONCE(self.a2c_counter),
                     bytes(block_and_tag),
                 )

--- a/aiohomekit/controller/ip/connection.py
+++ b/aiohomekit/controller/ip/connection.py
@@ -61,7 +61,7 @@ class InsecureHomeKitProtocol(asyncio.Protocol):
     def connection_lost(self, exception):
         self.connection._connection_lost(exception)
 
-    async def send_bytes(self, payload):
+    async def send_bytes(self, payload: bytes):
         if self.transport.is_closing():
             # FIXME: It would be nice to try and wait for the reconnect in future.
             # In that case we need to make sure we do it at a layer above send_bytes otherwise
@@ -120,7 +120,7 @@ class SecureHomeKitProtocol(InsecureHomeKitProtocol):
     def __init__(self, connection, a2c_key, c2a_key):
         super().__init__(connection)
 
-        self._incoming_buffer = bytearray()
+        self._incoming_buffer: bytearray = bytearray()
 
         self.c2a_counter = 0
         self.a2c_counter = 0
@@ -131,7 +131,7 @@ class SecureHomeKitProtocol(InsecureHomeKitProtocol):
         self.encryptor = ChaCha20Poly1305Encryptor(self.c2a_key)
         self.decryptor = ChaCha20Poly1305Decryptor(self.a2c_key)
 
-    async def send_bytes(self, payload):
+    async def send_bytes(self, payload: bytes):
         buffer: list[bytes] = []
 
         while len(payload) > 0:
@@ -180,7 +180,7 @@ class SecureHomeKitProtocol(InsecureHomeKitProtocol):
                 decrypted = self.decryptor.decrypt(
                     block_length_bytes,
                     PACK_NONCE(self.a2c_counter),
-                    block_and_tag,
+                    bytes(block_and_tag),
                 )
             except DecryptionError as err:
                 raise RuntimeError("Could not decrypt block") from err

--- a/aiohomekit/controller/ip/connection.py
+++ b/aiohomekit/controller/ip/connection.py
@@ -143,7 +143,7 @@ class SecureHomeKitProtocol(InsecureHomeKitProtocol):
                 self.encryptor.encrypt(
                     len_bytes,
                     PACK_NONCE(self.c2a_counter),
-                    current,
+                    bytes(current),
                 )
             )
             self.c2a_counter += 1

--- a/aiohomekit/controller/ip/connection.py
+++ b/aiohomekit/controller/ip/connection.py
@@ -14,14 +14,15 @@
 # limitations under the License.
 #
 from __future__ import annotations
+
 import asyncio
 import logging
 from typing import TYPE_CHECKING
 
 from aiohomekit.crypto.chacha20poly1305 import (
+    PACK_NONCE,
     ChaCha20Poly1305Decryptor,
     ChaCha20Poly1305Encryptor,
-    PACK_NONCE,
     DecryptionError,
 )
 from aiohomekit.exceptions import (

--- a/aiohomekit/controller/ip/connection.py
+++ b/aiohomekit/controller/ip/connection.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING
 from aiohomekit.crypto.chacha20poly1305 import (
     ChaCha20Poly1305Decryptor,
     ChaCha20Poly1305Encryptor,
+    PACK_NONCE,
     DecryptionError,
 )
 from aiohomekit.exceptions import (
@@ -140,7 +141,7 @@ class SecureHomeKitProtocol(InsecureHomeKitProtocol):
             buffer.append(
                 self.encryptor.encrypt(
                     len_bytes,
-                    self.c2a_counter,
+                    PACK_NONCE(self.c2a_counter),
                     current,
                 )
             )
@@ -177,7 +178,7 @@ class SecureHomeKitProtocol(InsecureHomeKitProtocol):
             try:
                 decrypted = self.decryptor.decrypt(
                     block_length_bytes,
-                    self.a2c_counter,
+                    PACK_NONCE(self.a2c_counter),
                     block_and_tag,
                 )
             except DecryptionError as err:

--- a/aiohomekit/controller/ip/connection.py
+++ b/aiohomekit/controller/ip/connection.py
@@ -172,9 +172,11 @@ class SecureHomeKitProtocol(InsecureHomeKitProtocol):
                 # Not enough data yet
                 return
 
-            block_and_tag = self._incoming_buffer[2 : block_length + 16]
-            # Drop the length, block, and tag from the buffer
-            del self._incoming_buffer[: 2 + block_length + 16]
+            # Drop the length from the top of the buffer as we have already parsed it
+            del self._incoming_buffer[:2]
+
+            block_and_tag = self._incoming_buffer[:block_length+16]
+            del self._incoming_buffer[:block_length+16]
 
             try:
                 decrypted = self.decryptor.decrypt(

--- a/aiohomekit/controller/ip/connection.py
+++ b/aiohomekit/controller/ip/connection.py
@@ -175,8 +175,8 @@ class SecureHomeKitProtocol(InsecureHomeKitProtocol):
             # Drop the length from the top of the buffer as we have already parsed it
             del self._incoming_buffer[:2]
 
-            block_and_tag = self._incoming_buffer[:block_length+16]
-            del self._incoming_buffer[:block_length+16]
+            block_and_tag = self._incoming_buffer[: block_length + 16]
+            del self._incoming_buffer[: block_length + 16]
 
             try:
                 decrypted = self.decryptor.decrypt(

--- a/aiohomekit/crypto/__init__.py
+++ b/aiohomekit/crypto/__init__.py
@@ -20,8 +20,17 @@ __all__ = [
     "hkdf_derive",
     "SrpClient",
     "SrpServer",
+    "DecryptionError",
+    "PACK_NONCE",
+    "NONCE_PADDING",
 ]
 
-from .chacha20poly1305 import ChaCha20Poly1305Decryptor, ChaCha20Poly1305Encryptor
+from .chacha20poly1305 import (
+    ChaCha20Poly1305Decryptor,
+    ChaCha20Poly1305Encryptor,
+    DecryptionError,
+    PACK_NONCE,
+    NONCE_PADDING,
+)
 from .hkdf import hkdf_derive
 from .srp import SrpClient, SrpServer

--- a/aiohomekit/crypto/__init__.py
+++ b/aiohomekit/crypto/__init__.py
@@ -26,11 +26,11 @@ __all__ = [
 ]
 
 from .chacha20poly1305 import (
+    NONCE_PADDING,
+    PACK_NONCE,
     ChaCha20Poly1305Decryptor,
     ChaCha20Poly1305Encryptor,
     DecryptionError,
-    PACK_NONCE,
-    NONCE_PADDING,
 )
 from .hkdf import hkdf_derive
 from .srp import SrpClient, SrpServer

--- a/aiohomekit/crypto/chacha20poly1305.py
+++ b/aiohomekit/crypto/chacha20poly1305.py
@@ -66,10 +66,7 @@ class ChaCha20Poly1305Encryptor:
         :param plaintext: arbitrary length plaintext of type bytes or bytearray
         :return: the cipher text and tag
         """
-        assert type(aad) is bytes, "aad is no instance of bytes"
-        assert type(plaintext) is bytes, "plaintext is no instance of bytes"
-        assert type(nonce) is bytes, "plaintext is no instance of bytes"
-        return self.chacha.encrypt(nonce, plaintext, bytes(aad))
+        return self.chacha.encrypt(nonce, plaintext, aad)
 
 
 class ChaCha20Poly1305Decryptor:
@@ -95,9 +92,6 @@ class ChaCha20Poly1305Decryptor:
         :param ciphertext: arbitrary length plaintext of type bytes or bytearray
         :return: False if the tag could not be verified or the plaintext as bytes
         """
-        assert type(aad) is bytes, "aad is no instance of bytes"
-        assert type(ciphertext) is bytes, "ciphertext is no instance of bytes"
-        assert type(nonce) is bytes, "nonce is no instance of bytes"
         return self.chacha.decrypt(nonce, ciphertext, aad)
 
 

--- a/aiohomekit/crypto/chacha20poly1305.py
+++ b/aiohomekit/crypto/chacha20poly1305.py
@@ -21,10 +21,11 @@ https://tools.ietf.org/html/rfc7539. See HomeKit spec page 51.
 
 from __future__ import annotations
 
+from functools import partial
 import logging
 import struct
-from functools import partial
 from struct import Struct
+
 from chacha20poly1305 import (
     ChaCha,
     ChaCha20Poly1305 as ChaCha20Poly1305PurePython,

--- a/aiohomekit/protocol/__init__.py
+++ b/aiohomekit/protocol/__init__.py
@@ -275,7 +275,7 @@ def perform_pair_setup_part2(
     # https://github.com/KhaosT/HAP-NodeJS/blob/2ea9d761d9bd7593dd1949fec621ab085af5e567/lib/HAPServer.js
     # function handlePairStepFive calling encryption.encryptAndSeal
     encrypted_data_with_auth_tag = ChaCha20Poly1305Encryptor(session_key).encrypt(
-        b"", NONCE_PADDING + b"PS-Msg05", sub_tlv_b
+        b"", NONCE_PADDING + b"PS-Msg05", bytes(sub_tlv_b)
     )
 
     response_tlv = [
@@ -568,7 +568,7 @@ def get_session_keys(
 
     # 10) encrypt and sign
     encrypted_data_with_auth_tag = ChaCha20Poly1305Encryptor(session_key).encrypt(
-        b"", NONCE_PADDING + b"PV-Msg03", sub_tlv
+        b"", NONCE_PADDING + b"PV-Msg03", bytes(sub_tlv)
     )
 
     # 11) create tlv

--- a/aiohomekit/protocol/__init__.py
+++ b/aiohomekit/protocol/__init__.py
@@ -307,7 +307,7 @@ def perform_pair_setup_part2(
     if decrypted_data is False:
         raise IllegalData("step 7")
 
-    response_tlv = TLV.decode_bytearray(decrypted_data)
+    response_tlv = TLV.decode_bytearray(bytearray(decrypted_data))
     response_tlv = dict(response_tlv)
 
     if TLV.kTLVType_Signature not in response_tlv:

--- a/aiohomekit/protocol/__init__.py
+++ b/aiohomekit/protocol/__init__.py
@@ -27,6 +27,7 @@ from cryptography.hazmat.primitives.asymmetric import ed25519, x25519
 from aiohomekit.crypto import (
     ChaCha20Poly1305Decryptor,
     ChaCha20Poly1305Encryptor,
+    NONCE_PADDING,
     SrpClient,
     hkdf_derive,
 )
@@ -143,8 +144,7 @@ def validate_mfi(session_key, response_tlv):
     # It should have a signature and a certificate from an Apple secure co-processor.
     decrypted = ChaCha20Poly1305Decryptor(session_key).decrypt(
         b"",
-        b"PS-Msg04",
-        bytes([0, 0, 0, 0]),
+        NONCE_PADDING + b"PS-Msg04",
         response_tlv[TLV.kTLVType_EncryptedData],
     )
 
@@ -275,7 +275,7 @@ def perform_pair_setup_part2(
     # https://github.com/KhaosT/HAP-NodeJS/blob/2ea9d761d9bd7593dd1949fec621ab085af5e567/lib/HAPServer.js
     # function handlePairStepFive calling encryption.encryptAndSeal
     encrypted_data_with_auth_tag = ChaCha20Poly1305Encryptor(session_key).encrypt(
-        b"", b"PS-Msg05", bytes([0, 0, 0, 0]), sub_tlv_b
+        b"", NONCE_PADDING + b"PS-Msg05", sub_tlv_b
     )
 
     response_tlv = [
@@ -301,8 +301,7 @@ def perform_pair_setup_part2(
 
     decrypted_data = ChaCha20Poly1305Decryptor(session_key).decrypt(
         b"",
-        b"PS-Msg06",
-        bytes([0, 0, 0, 0]),
+        NONCE_PADDING + b"PS-Msg06",
         response_tlv[TLV.kTLVType_EncryptedData],
     )
     if decrypted_data is False:
@@ -368,8 +367,7 @@ def resume_m1(
 
     auth_tag = key.encrypt(
         b"",
-        b"PR-Msg01",
-        bytes([0, 0, 0, 0]),
+        NONCE_PADDING + b"PR-Msg01",
         b"",
     )
 
@@ -411,8 +409,7 @@ def resume_m3(
     key = ChaCha20Poly1305Decryptor(response_key)
     plaintext = key.decrypt(
         b"",
-        b"PR-Msg02",
-        bytes([0, 0, 0, 0]),
+        NONCE_PADDING + b"PR-Msg02",
         auth_tag,
     )
 
@@ -509,7 +506,7 @@ def get_session_keys(
     # 3) verify auth tag on encrypted data and 4) decrypt
     encrypted = response_tlv[TLV.kTLVType_EncryptedData]
     decrypted = ChaCha20Poly1305Decryptor(session_key).decrypt(
-        b"", b"PV-Msg02", bytes([0, 0, 0, 0]), encrypted
+        b"", NONCE_PADDING + b"PV-Msg02", encrypted
     )
     if type(decrypted) == bool and not decrypted:
         raise InvalidAuthTagError("step 3")
@@ -571,7 +568,7 @@ def get_session_keys(
 
     # 10) encrypt and sign
     encrypted_data_with_auth_tag = ChaCha20Poly1305Encryptor(session_key).encrypt(
-        b"", b"PV-Msg03", bytes([0, 0, 0, 0]), sub_tlv
+        b"", NONCE_PADDING + b"PV-Msg03", sub_tlv
     )
 
     # 11) create tlv

--- a/aiohomekit/protocol/__init__.py
+++ b/aiohomekit/protocol/__init__.py
@@ -145,7 +145,7 @@ def validate_mfi(session_key, response_tlv):
     decrypted = ChaCha20Poly1305Decryptor(session_key).decrypt(
         b"",
         NONCE_PADDING + b"PS-Msg04",
-        response_tlv[TLV.kTLVType_EncryptedData],
+        bytes(response_tlv[TLV.kTLVType_EncryptedData]),
     )
 
     if not decrypted:
@@ -302,7 +302,7 @@ def perform_pair_setup_part2(
     decrypted_data = ChaCha20Poly1305Decryptor(session_key).decrypt(
         b"",
         NONCE_PADDING + b"PS-Msg06",
-        response_tlv[TLV.kTLVType_EncryptedData],
+        bytes(response_tlv[TLV.kTLVType_EncryptedData]),
     )
     if decrypted_data is False:
         raise IllegalData("step 7")
@@ -410,7 +410,7 @@ def resume_m3(
     plaintext = key.decrypt(
         b"",
         NONCE_PADDING + b"PR-Msg02",
-        auth_tag,
+        bytes(auth_tag),
     )
 
     if plaintext != b"":
@@ -506,7 +506,7 @@ def get_session_keys(
     # 3) verify auth tag on encrypted data and 4) decrypt
     encrypted = response_tlv[TLV.kTLVType_EncryptedData]
     decrypted = ChaCha20Poly1305Decryptor(session_key).decrypt(
-        b"", NONCE_PADDING + b"PV-Msg02", encrypted
+        b"", NONCE_PADDING + b"PV-Msg02", bytes(encrypted)
     )
     if type(decrypted) == bool and not decrypted:
         raise InvalidAuthTagError("step 3")

--- a/aiohomekit/protocol/__init__.py
+++ b/aiohomekit/protocol/__init__.py
@@ -25,9 +25,9 @@ from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import ed25519, x25519
 
 from aiohomekit.crypto import (
+    NONCE_PADDING,
     ChaCha20Poly1305Decryptor,
     ChaCha20Poly1305Encryptor,
-    NONCE_PADDING,
     SrpClient,
     hkdf_derive,
 )

--- a/tests/accessoryserver.py
+++ b/tests/accessoryserver.py
@@ -1441,7 +1441,7 @@ class AccessoryRequestHandler(BaseHTTPRequestHandler):
                 self.log_error("error in step #6 %s %s", d_res, self.server.sessions)
                 return
 
-            d_req_2 = TLV.decode_bytearray(decrypted_data)
+            d_req_2 = TLV.decode_bytearray(bytearray(decrypted_data))
 
             # 3) Derive ios_device_x
             shared_secret = self.server.sessions[self.session_id][

--- a/tests/accessoryserver.py
+++ b/tests/accessoryserver.py
@@ -35,6 +35,9 @@ from aiohomekit.crypto import hkdf_derive
 from aiohomekit.crypto.chacha20poly1305 import (
     ChaCha20Poly1305Decryptor,
     ChaCha20Poly1305Encryptor,
+    DecryptionError,
+    NONCE_PADDING,
+    PACK_NONCE,
 )
 from aiohomekit.crypto.srp import SrpServer
 from aiohomekit.exceptions import (
@@ -390,7 +393,7 @@ class AccessoryRequestHandler(BaseHTTPRequestHandler):
 
     def write_event(self, characteristics):
         tmp = []
-        for (aid, iid) in characteristics:
+        for aid, iid in characteristics:
             if (aid, iid) not in self.subscriptions:
                 continue
 
@@ -432,11 +435,11 @@ class AccessoryRequestHandler(BaseHTTPRequestHandler):
                 a2c_key = self.server.sessions[self.session_id][
                     "accessory_to_controller_key"
                 ]
-                cnt_bytes = self.server.sessions[self.session_id][
+                cnt = self.server.sessions[self.session_id][
                     "accessory_to_controller_count"
-                ].to_bytes(8, byteorder="little")
+                ]
                 ciper_and_mac = ChaCha20Poly1305Encryptor(a2c_key).encrypt(
-                    len_bytes, cnt_bytes, bytes([0, 0, 0, 0]), block
+                    len_bytes, PACK_NONCE(cnt), block
                 )
                 self.server.sessions[self.session_id][
                     "accessory_to_controller_count"
@@ -513,13 +516,12 @@ class AccessoryRequestHandler(BaseHTTPRequestHandler):
         c2a_key = self.server.sessions[self.session_id]["controller_to_accessory_key"]
 
         # verify & decrypt the read data
-        cnt_bytes = self.server.sessions[self.session_id][
-            "controller_to_accessory_count"
-        ].to_bytes(8, byteorder="little")
-        decrypted = ChaCha20Poly1305Decryptor(c2a_key).decrypt(
-            len_bytes, cnt_bytes, bytes([0, 0, 0, 0]), data
-        )
-        if decrypted is False:
+        cnt = self.server.sessions[self.session_id]["controller_to_accessory_count"]
+        try:
+            decrypted = ChaCha20Poly1305Decryptor(c2a_key).decrypt(
+                len_bytes, PACK_NONCE(cnt), data
+            )
+        except DecryptionError:
             # crypto error, log it and request close of connection
             self.log_error("SEVERE: Could not decrypt %s", binascii.hexlify(data))
             self.close_connection = True
@@ -864,7 +866,6 @@ class AccessoryRequestHandler(BaseHTTPRequestHandler):
             self.end_headers()
 
     def _get_accessories(self):
-
         result_bytes = self.server.accessories.to_accessory_and_service_list().encode()
         self.send_response(HttpStatusCodes.OK)
         self.send_header("Content-Type", "application/hap+json")
@@ -941,8 +942,7 @@ class AccessoryRequestHandler(BaseHTTPRequestHandler):
                 session_key
             ).encrypt(
                 b"",
-                b"PV-Msg02",
-                bytes([0, 0, 0, 0]),
+                NONCE_PADDING + b"PV-Msg02",
                 sub_tlv_b,
             )
 
@@ -971,13 +971,13 @@ class AccessoryRequestHandler(BaseHTTPRequestHandler):
             # 1) verify ios' authtag
             # 2) decrypt
             encrypted = d_req[1][1]
-            decrypted = ChaCha20Poly1305Decryptor(session_key).decrypt(
-                b"",
-                b"PV-Msg03",
-                bytes([0, 0, 0, 0]),
-                encrypted,
-            )
-            if decrypted is False:
+            try:
+                decrypted = ChaCha20Poly1305Decryptor(session_key).decrypt(
+                    b"",
+                    NONCE_PADDING + b"PV-Msg03",
+                    encrypted,
+                )
+            except DecryptionError:
                 self.send_error_reply(TLV.M4, TLV.kTLVError_Authentication)
                 self.log_error(
                     "error in step #4: authtag %s %s", d_res, self.server.sessions
@@ -1415,15 +1415,15 @@ class AccessoryRequestHandler(BaseHTTPRequestHandler):
 
             # 2) decrypt and test
             encrypted_data = d_req[1][1]
-            decrypted_data = ChaCha20Poly1305Decryptor(
-                self.server.sessions[self.session_id]["session_key"]
-            ).decrypt(
-                b"",
-                b"PS-Msg05",
-                bytes([0, 0, 0, 0]),
-                encrypted_data,
-            )
-            if decrypted_data is False:
+            try:
+                decrypted_data = ChaCha20Poly1305Decryptor(
+                    self.server.sessions[self.session_id]["session_key"]
+                ).decrypt(
+                    b"",
+                    NONCE_PADDING + b"PS-Msg05",
+                    encrypted_data,
+                )
+            except DecryptionError:
                 d_res.append(
                     (
                         TLV.kTLVType_State,
@@ -1533,8 +1533,7 @@ class AccessoryRequestHandler(BaseHTTPRequestHandler):
                 self.server.sessions[self.session_id]["session_key"]
             ).encrypt(
                 b"",
-                b"PS-Msg06",
-                bytes([0, 0, 0, 0]),
+                NONCE_PADDING + b"PS-Msg06",
                 sub_tlv_b,
             )
 

--- a/tests/accessoryserver.py
+++ b/tests/accessoryserver.py
@@ -33,11 +33,11 @@ from zeroconf import ServiceInfo, Zeroconf
 
 from aiohomekit.crypto import hkdf_derive
 from aiohomekit.crypto.chacha20poly1305 import (
+    NONCE_PADDING,
+    PACK_NONCE,
     ChaCha20Poly1305Decryptor,
     ChaCha20Poly1305Encryptor,
     DecryptionError,
-    NONCE_PADDING,
-    PACK_NONCE,
 )
 from aiohomekit.crypto.srp import SrpServer
 from aiohomekit.exceptions import (

--- a/tests/accessoryserver.py
+++ b/tests/accessoryserver.py
@@ -439,7 +439,7 @@ class AccessoryRequestHandler(BaseHTTPRequestHandler):
                     "accessory_to_controller_count"
                 ]
                 ciper_and_mac = ChaCha20Poly1305Encryptor(a2c_key).encrypt(
-                    len_bytes, PACK_NONCE(cnt), block
+                    len_bytes, PACK_NONCE(cnt), bytes(block)
                 )
                 self.server.sessions[self.session_id][
                     "accessory_to_controller_count"
@@ -943,7 +943,7 @@ class AccessoryRequestHandler(BaseHTTPRequestHandler):
             ).encrypt(
                 b"",
                 NONCE_PADDING + b"PV-Msg02",
-                sub_tlv_b,
+                bytes(sub_tlv_b),
             )
 
             # 8) construct result tlv
@@ -975,7 +975,7 @@ class AccessoryRequestHandler(BaseHTTPRequestHandler):
                 decrypted = ChaCha20Poly1305Decryptor(session_key).decrypt(
                     b"",
                     NONCE_PADDING + b"PV-Msg03",
-                    encrypted,
+                    bytes(encrypted),
                 )
             except DecryptionError:
                 self.send_error_reply(TLV.M4, TLV.kTLVError_Authentication)
@@ -1421,7 +1421,7 @@ class AccessoryRequestHandler(BaseHTTPRequestHandler):
                 ).decrypt(
                     b"",
                     NONCE_PADDING + b"PS-Msg05",
-                    encrypted_data,
+                    bytes(encrypted_data),
                 )
             except DecryptionError:
                 d_res.append(
@@ -1534,7 +1534,7 @@ class AccessoryRequestHandler(BaseHTTPRequestHandler):
             ).encrypt(
                 b"",
                 NONCE_PADDING + b"PS-Msg06",
-                sub_tlv_b,
+                bytes(sub_tlv_b),
             )
 
             # 7) send response

--- a/tests/test_coap_structs.py
+++ b/tests/test_coap_structs.py
@@ -54,7 +54,6 @@ c3ba40437fac1188ab340a0250000c07190000270100000000131505020a\
 
 
 def test_coap_pdu09_encode_1():
-
     c_identity = Pdu09CharacteristicContainer(
         Pdu09Characteristic(
             0x14, 2, 0x0200, b"\x01\x00\x00\x27\x01\x00\x00", None, None, None, None

--- a/tests/test_controller_coap_pdu.py
+++ b/tests/test_controller_coap_pdu.py
@@ -9,28 +9,24 @@ from aiohomekit.controller.coap.pdu import (
 
 
 def test_encode_without_data():
-
     req_pdu = encode_pdu(OpCode.CHAR_READ, 0x10, 0x2022, b"")
 
     assert req_pdu == b"\x00\x03\x10\x22\x20\x00\x00"
 
 
 def test_encode_with_data():
-
     req_pdu = encode_pdu(OpCode.CHAR_WRITE, 0x20, 0x1234, b"\x01\x02\x03\x04")
 
     assert req_pdu == b"\x00\x02\x20\x34\x12\x04\x00\x01\x02\x03\x04"
 
 
 def test_encode_all_without_data():
-
     req_pdu = encode_all_pdus(OpCode.CHAR_READ, [0x10, 0x11], [b"", b""])
 
     assert req_pdu == b"\x00\x03\x00\x10\x00\x00\x00" + b"\x00\x03\x01\x11\x00\x00\x00"
 
 
 def test_encode_all_with_data():
-
     req_pdu = encode_all_pdus(
         OpCode.CHAR_WRITE, [0x12, 0x13], [b"\x88\x88", b"\x99\x99\x99\x99"]
     )
@@ -43,7 +39,6 @@ def test_encode_all_with_data():
 
 
 def test_decode_without_data():
-
     res_pdu = b"\x02\x40\x00\x00\x00"
     res_len, res_val = decode_pdu(0x40, res_pdu)
 
@@ -52,7 +47,6 @@ def test_decode_without_data():
 
 
 def test_decode_with_data():
-
     res_pdu = b"\x02\x50\x00\x06\x00\x01\x01\x01\x02\x01\x00"
     res_len, res_val = decode_pdu(0x50, res_pdu)
 
@@ -61,7 +55,6 @@ def test_decode_with_data():
 
 
 def test_decode_all_without_data():
-
     res_pdu = b"\x02\x20\x00\x00\x00" + b"\x02\x21\x00\x00\x00"
     res = decode_all_pdus(0x20, res_pdu)
 
@@ -73,7 +66,6 @@ def test_decode_all_without_data():
 
 
 def test_decode_all_with_data():
-
     res_pdu = b"\x02\x30\x00\x02\x00\x01\x00" + b"\x02\x31\x00\x02\x00\x02\x00"
     res = decode_all_pdus(0x30, res_pdu)
 
@@ -85,7 +77,6 @@ def test_decode_all_with_data():
 
 
 def test_decode_all_with_single_bad_tid():
-
     res_pdu = (
         b"\x02\x40\x00\x02\x00\x03\x00"
         + b"\x02\x99\x00\x02\x00\x04\x00"
@@ -103,7 +94,6 @@ def test_decode_all_with_single_bad_tid():
 
 
 def test_decode_all_with_single_status_error():
-
     res_pdu = (
         b"\x02\x50\x00\x00\x00"
         + b"\x02\x51\x06\x00\x00"
@@ -121,7 +111,6 @@ def test_decode_all_with_single_status_error():
 
 
 def test_decode_all_with_single_bad_control():
-
     res_pdu = (
         b"\x02\x50\x00\x00\x00"
         + b"\x08\x51\x00\x00\x00"
@@ -139,7 +128,6 @@ def test_decode_all_with_single_bad_control():
 
 
 def test_decode_with_bad_tid():
-
     res_pdu = b"\x02\x99\x00\x00\x00"
     res_len, res_val = decode_pdu(0x60, res_pdu)
 
@@ -148,7 +136,6 @@ def test_decode_with_bad_tid():
 
 
 def test_decode_with_status_error():
-
     res_pdu = b"\x02\x99\x06\x00\x00"
     res_len, res_val = decode_pdu(0x99, res_pdu)
 
@@ -158,7 +145,6 @@ def test_decode_with_status_error():
 
 
 def test_decode_with_bad_control():
-
     res_pdu = b"\xCC\x99\x00\x00\x00"
     res_len, res_val = decode_pdu(0x99, res_pdu)
 

--- a/tests/test_controller_ip_controller.py
+++ b/tests/test_controller_ip_controller.py
@@ -162,7 +162,6 @@ async def test_find_device_id_case_upper(mock_asynczeroconf: AsyncZeroconf):
     svc_info._set_properties(svc_info.properties)
 
     with _install_mock_service_info(mock_asynczeroconf, svc_info):
-
         async with controller:
             await controller._async_update_from_cache(mock_asynczeroconf.zeroconf)
             res = await controller.async_find("aa:aa:aa:aa:aa:aa")
@@ -244,7 +243,6 @@ async def test_discover_device_id_case_lower(mock_asynczeroconf: AsyncZeroconf):
     svc_info._set_properties(svc_info.properties)
 
     with _install_mock_service_info(mock_asynczeroconf, svc_info):
-
         async with controller:
             await controller._async_update_from_cache(mock_asynczeroconf.zeroconf)
 
@@ -263,7 +261,6 @@ async def test_discover_device_id_case_upper(mock_asynczeroconf: AsyncZeroconf):
     svc_info._set_properties(svc_info.properties)
 
     with _install_mock_service_info(mock_asynczeroconf, svc_info):
-
         async with controller:
             await controller._async_update_from_cache(mock_asynczeroconf.zeroconf)
 

--- a/tests/test_crypto_chacha20poly1305.py
+++ b/tests/test_crypto_chacha20poly1305.py
@@ -14,12 +14,13 @@
 # limitations under the License.
 #
 
+import pytest
+
 from aiohomekit.crypto.chacha20poly1305 import (
     ChaCha20Poly1305Decryptor,
     ChaCha20Poly1305Encryptor,
     DecryptionError,
 )
-import pytest
 
 
 def test_example2_8_2():

--- a/tests/test_crypto_chacha20poly1305.py
+++ b/tests/test_crypto_chacha20poly1305.py
@@ -17,8 +17,6 @@
 from aiohomekit.crypto.chacha20poly1305 import (
     ChaCha20Poly1305Decryptor,
     ChaCha20Poly1305Encryptor,
-    PACK_NONCE,
-    NONCE_PADDING,
     DecryptionError,
 )
 import pytest

--- a/tests/test_crypto_chacha20poly1305.py
+++ b/tests/test_crypto_chacha20poly1305.py
@@ -17,6 +17,8 @@
 from aiohomekit.crypto.chacha20poly1305 import (
     ChaCha20Poly1305Decryptor,
     ChaCha20Poly1305Encryptor,
+    PACK_NONCE,
+    NONCE_PADDING,
 )
 
 
@@ -172,15 +174,15 @@ def test_example2_8_2():
             ]
         ),
     )
-
-    r = ChaCha20Poly1305Encryptor(key).encrypt(aad, iv, fixed, plain_text)
+    nonce = fixed + iv
+    r = ChaCha20Poly1305Encryptor(key).encrypt(aad, nonce, plain_text)
     assert r[:-16] == r_[0], "ciphertext"
     assert r[-16:] == r_[1], "tag"
 
-    plain_text_ = ChaCha20Poly1305Decryptor(key).decrypt(aad, iv, fixed, r)
+    plain_text_ = ChaCha20Poly1305Decryptor(key).decrypt(aad, nonce, r)
     assert plain_text == plain_text_
 
     assert (
-        ChaCha20Poly1305Decryptor(key).decrypt(aad, iv, fixed, r + bytes([0, 1, 2, 3]))
+        ChaCha20Poly1305Decryptor(key).decrypt(aad, nonce, r + bytes([0, 1, 2, 3]))
         is False
     )

--- a/tests/test_crypto_chacha20poly1305.py
+++ b/tests/test_crypto_chacha20poly1305.py
@@ -19,7 +19,9 @@ from aiohomekit.crypto.chacha20poly1305 import (
     ChaCha20Poly1305Encryptor,
     PACK_NONCE,
     NONCE_PADDING,
+    DecryptionError,
 )
+import pytest
 
 
 def test_example2_8_2():
@@ -182,7 +184,5 @@ def test_example2_8_2():
     plain_text_ = ChaCha20Poly1305Decryptor(key).decrypt(aad, nonce, r)
     assert plain_text == plain_text_
 
-    assert (
+    with pytest.raises(DecryptionError):
         ChaCha20Poly1305Decryptor(key).decrypt(aad, nonce, r + bytes([0, 1, 2, 3]))
-        is False
-    )

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -2,7 +2,6 @@ from aiohomekit.enum import EnumWithDescription
 
 
 class EnumTest(EnumWithDescription):
-
     RED = 1, "The colour is red"
     BLUE = 2, "This colour is blue"
 


### PR DESCRIPTION
I was testing with some cameras and noticed the image encryption overhead was showing up in the profile

- Implement the todo to not return `False`