### PR TITLE
Make HomeKitService slotted

### DIFF
--- a/aiohomekit/zeroconf.py
+++ b/aiohomekit/zeroconf.py
@@ -21,9 +21,7 @@ from abc import abstractmethod
 import asyncio
 from collections.abc import AsyncIterable
 from dataclasses import dataclass
-from functools import partial
 import logging
-import sys
 
 import async_timeout
 from zeroconf import (
@@ -59,13 +57,8 @@ _TIMEOUT_MS = 3000
 
 logger = logging.getLogger(__name__)
 
-if sys.version_info[:2] < (3, 10):
-    _dataclass_decorator = dataclass
-else:
-    _dataclass_decorator = partial(dataclass, slots=True)
 
-
-@_dataclass_decorator
+@dataclass(slots=True)
 class HomeKitService:
     name: str
     id: str


### PR DESCRIPTION
We tend to have a lot of these in memory if there are a lot of HomeKit devices on the network (even if they are not paired to HKC)