### PR TITLE
Workaround invalid minStep values

### DIFF
--- a/aiohomekit/model/characteristics/characteristic.py
+++ b/aiohomekit/model/characteristics/characteristic.py
@@ -360,7 +360,7 @@ def check_convert_value(val: str, char: Characteristic) -> Any:
         # Honeywell T6 Pro cannot handle arbritary precision, the values we send
         # *must* respect minStep
         # See https://github.com/home-assistant/core/issues/37083
-        if char.minStep is not None:
+        if char.minStep:
             with localcontext() as ctx:
                 ctx.prec = 6
 


### PR DESCRIPTION
Currently if minStep is present but `0` it causes a division error. `0` is not a valid value for minStep, so bypass clamping as if it wasn't there at all.

Fixes https://github.com/home-assistant/core/issues/100183.