### PR TITLE
Make process_changes return a set of what actually changed

### DIFF
--- a/aiohomekit/model/__init__.py
+++ b/aiohomekit/model/__init__.py
@@ -27,6 +27,7 @@ from aiohomekit.uuid import normalize_uuid
 from . import entity_map
 from .categories import Categories
 from .characteristics import (
+    EVENT_CHARACTERISTICS,
     Characteristic,
     CharacteristicFormats,
     CharacteristicPermissions,
@@ -421,7 +422,7 @@ class Accessories:
                 continue
 
             if "value" in value:
-                if char.set_value(value["value"]):
+                if char.set_value(value["value"]) or char.type in EVENT_CHARACTERISTICS:
                     changed.add(aid_iid)
 
             previous_status = char.status

--- a/aiohomekit/model/__init__.py
+++ b/aiohomekit/model/__init__.py
@@ -407,16 +407,29 @@ class Accessories:
         """Return True if the given aid exists."""
         return aid in self._aid_to_accessory
 
-    def process_changes(self, changes: dict[tuple[int, int], dict[str, Any]]) -> None:
-        """Process changes from a HomeKit controller."""
-        for (aid, iid), value in changes.items():
+    def process_changes(
+        self, changes: dict[tuple[int, int], dict[str, Any]]
+    ) -> set[tuple[int, int]]:
+        """Process changes from a HomeKit controller.
+
+        Returns a set of the changes that were applied.
+        """
+        changed: set[tuple[int, int]] = set()
+        for aid_iid, value in changes.items():
+            (aid, iid) = aid_iid
             if not (char := self.aid(aid).characteristics.iid(iid)):
                 continue
 
             if "value" in value:
-                char.set_value(value["value"])
+                if char.set_value(value["value"]):
+                    changed.add(aid_iid)
 
+            previous_status = char.status
             char.status = to_status_code(value.get("status", 0))
+            if previous_status != char.status:
+                changed.add(aid_iid)
+
+        return changed
 
 
 @dataclass

--- a/aiohomekit/model/characteristics/characteristic.py
+++ b/aiohomekit/model/characteristics/characteristic.py
@@ -175,16 +175,20 @@ class Characteristic:
     def set_events(self, new_val: Any) -> None:
         self.ev = new_val
 
-    def set_value(self, new_val: Any) -> None:
+    def set_value(self, new_val: Any) -> bool:
         """
         This function sets the value of this characteristic.
+
+        Returns True if the value has changed, False otherwise.
         """
 
         if self.format == CharacteristicFormats.bool:
             # Device might return 1 or 0, so lets case to True/False
             new_val = bool(new_val)
 
+        changed = self._value != new_val
         self._value = new_val
+        return changed
 
     @property
     def value(self) -> Any:

--- a/aiohomekit/protocol/statuscodes.py
+++ b/aiohomekit/protocol/statuscodes.py
@@ -41,8 +41,7 @@ class HapStatusCode(EnumWithDescription):
 
 def to_status_code(status_code: int) -> HapStatusCode:
     # Some HAP implementations return positive values for error code (myq)
-    status_code = abs(status_code) * -1
-    return HapStatusCode(status_code)
+    return HapStatusCode(abs(status_code) * -1)
 
 
 class _HapBleStatusCodes:

--- a/aiohomekit/testing.py
+++ b/aiohomekit/testing.py
@@ -165,6 +165,21 @@ class PairingTester:
     def update_aid_iid(self, characteristics):
         self._send_events(characteristics)
 
+    def set_aid_iid_status(self, aid_iid_statuses: list[tuple[int, int, int]]):
+        """Set status for an aid iid pair."""
+        event = {
+            (aid, iid): {"status": status} for aid, iid, status in aid_iid_statuses
+        }
+
+        if not event:
+            return
+
+        for listener in self.pairing.listeners:
+            try:
+                listener(event)
+            except Exception:
+                _LOGGER.exception("Unhandled error when processing event")
+
     def _send_events(self, characteristics):
         if not self.events_enabled:
             return

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -215,7 +215,11 @@ def test_process_changes():
     on_char = accessories.aid(1).characteristics.iid(8)
     assert on_char.value is False
 
-    accessories.process_changes({(1, 8): {"value": True}})
+    changed = accessories.process_changes({(1, 8): {"value": True}})
+    assert changed == {(1, 8)}
+
+    changed = accessories.process_changes({(1, 8): {"value": True}})
+    assert changed == set()
 
     assert on_char.value is True
 
@@ -227,14 +231,16 @@ def test_process_changes_error():
     assert on_char.value is False
     assert on_char.status == HapStatusCode.SUCCESS
 
-    accessories.process_changes(
+    changed = accessories.process_changes(
         {(1, 8): {"status": HapStatusCode.UNABLE_TO_COMMUNICATE.value}}
     )
 
     assert on_char.value is False
     assert on_char.status == HapStatusCode.UNABLE_TO_COMMUNICATE
+    assert changed == {(1, 8)}
 
-    accessories.process_changes({(1, 8): {"value": True}})
+    changed = accessories.process_changes({(1, 8): {"value": True}})
+    assert changed == {(1, 8)}
     assert on_char.value is True
     assert on_char.status == HapStatusCode.SUCCESS
 
@@ -248,15 +254,17 @@ def test_process_changes_availability():
     assert on_char.service.available is True
     assert on_char.service.accessory.available is True
 
-    accessories.process_changes(
+    changed = accessories.process_changes(
         {(1, 8): {"status": HapStatusCode.UNABLE_TO_COMMUNICATE.value}}
     )
+    assert changed == {(1, 8)}
 
     assert on_char.available is False
     assert on_char.service.available is False
     assert on_char.service.accessory.available is False
 
-    accessories.process_changes({(1, 8): {"value": True}})
+    changed = accessories.process_changes({(1, 8): {"value": True}})
+    assert changed == {(1, 8)}
     assert on_char.available is True
     assert on_char.service.available is True
     assert on_char.service.accessory.available is True


### PR DESCRIPTION
I realized we still write state too frequently. When we do the poll if the value is the same we still callback the entity.

Will be used in https://github.com/home-assistant/core/pull/102370