### PR TITLE
Handle Aqara sensor having invalid md=

### DIFF
--- a/aiohomekit/zeroconf.py
+++ b/aiohomekit/zeroconf.py
@@ -99,7 +99,8 @@ class HomeKitService:
 
         props: dict[str, str] = {
             k.decode("utf-8").lower(): v.decode("utf-8")
-            for (k, v) in service.properties.items() if v
+            for (k, v) in service.properties.items()
+            if v is not None
         }
 
         if "id" not in props:

--- a/aiohomekit/zeroconf.py
+++ b/aiohomekit/zeroconf.py
@@ -99,7 +99,7 @@ class HomeKitService:
 
         props: dict[str, str] = {
             k.decode("utf-8").lower(): v.decode("utf-8")
-            for (k, v) in service.properties.items()
+            for (k, v) in service.properties.items() if v
         }
 
         if "id" not in props:


### PR DESCRIPTION
When TXT record is "\x03md=" zeroconf gives us a None. I thought that was a type violation, but that is indeed expected so update aiohomekit to cope with it.

We already have code paths to cope with missing records, so just drop empty fields so we pick up existing defaults.