### PR TITLE
Ensure all transports can handle an iterable in get_characteristics

### DIFF
--- a/aiohomekit/controller/abstract.py
+++ b/aiohomekit/controller/abstract.py
@@ -303,12 +303,12 @@ class AbstractPairing(metaclass=ABCMeta):
     @abstractmethod
     async def get_characteristics(
         self,
-        characteristics,
-        include_meta=False,
-        include_perms=False,
-        include_type=False,
-        include_events=False,
-    ):
+        characteristics: Iterable[tuple[int, int]],
+        include_meta: bool = False,
+        include_perms: bool = False,
+        include_type: bool = False,
+        include_events: bool = False,
+    ) -> dict[tuple[int, int], dict[str, Any]]:
         """Get characteristics."""
 
     @abstractmethod

--- a/aiohomekit/controller/ble/pairing.py
+++ b/aiohomekit/controller/ble/pairing.py
@@ -1289,7 +1289,7 @@ class BlePairing(AbstractPairing):
     @disconnect_on_missing_services
     async def get_characteristics(
         self,
-        characteristics: list[tuple[int, int]],
+        characteristics: Iterable[tuple[int, int]],
     ) -> dict[tuple[int, int], dict[str, Any]]:
         return await self._get_characteristics_without_retry(characteristics)
 
@@ -1328,7 +1328,7 @@ class BlePairing(AbstractPairing):
     @restore_connection_and_resume
     async def _get_characteristics_without_retry(
         self,
-        characteristics: list[tuple[int, int]],
+        characteristics: Iterable[tuple[int, int]],
         notify_listeners: bool = False,
     ) -> dict[tuple[int, int], dict[str, Any]]:
         accessory_chars = self.accessories.aid(BLE_AID).characteristics

--- a/aiohomekit/controller/coap/connection.py
+++ b/aiohomekit/controller/coap/connection.py
@@ -17,10 +17,11 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Iterable
 import logging
 import random
 import struct
-from typing import Any, Iterable
+from typing import Any
 import uuid
 
 from aiocoap import Context, Message, resource

--- a/aiohomekit/controller/coap/connection.py
+++ b/aiohomekit/controller/coap/connection.py
@@ -20,7 +20,7 @@ import asyncio
 import logging
 import random
 import struct
-from typing import Any
+from typing import Any, Iterable
 import uuid
 
 from aiocoap import Context, Message, resource
@@ -502,8 +502,15 @@ class CoAPHomeKitConnection:
         logger.debug(f"Read characteristics: {results!r}")
         return results
 
-    async def read_characteristics(self, ids: list[tuple[int, int]]):
-        iids = [int(aid_iid[1]) for aid_iid in ids]
+    async def read_characteristics(
+        self, characteristics: Iterable[tuple[int, int]]
+    ) -> dict[tuple[int, int], dict[str, Any]]:
+        """Read characteristics from the accessory."""
+        # _read_characteristics_exit expects a list of tuples
+        # as it does an ordered read so we need to convert
+        # to a list to preserve the order
+        ids = list(characteristics)
+        iids = [int(aid_iid[1]) for aid_iid in characteristics]
         data = [b""] * len(iids)
         pdu_results = await self.enc_ctx.post_all(OpCode.CHAR_READ, iids, data)
         return self._read_characteristics_exit(ids, pdu_results)

--- a/aiohomekit/controller/coap/pairing.py
+++ b/aiohomekit/controller/coap/pairing.py
@@ -191,8 +191,8 @@ class CoAPPairing(ZeroconfPairing):
 
     async def get_characteristics(
         self,
-        characteristics,
-    ):
+        characteristics: Iterable[tuple[int, int]],
+    ) -> dict[tuple[int, int], dict[str, Any]]:
         await self._ensure_connected()
         return await self.connection.read_characteristics(characteristics)
 

--- a/aiohomekit/controller/ip/pairing.py
+++ b/aiohomekit/controller/ip/pairing.py
@@ -243,8 +243,8 @@ class IpPairing(ZeroconfPairing):
 
     async def get_characteristics(
         self,
-        characteristics,
-    ):
+        characteristics: Iterable[tuple[int, int]],
+    ) -> dict[tuple[int, int], dict[str, Any]]:
         """
         This method is used to get the current readouts of any characteristic of the accessory.
 
@@ -266,8 +266,13 @@ class IpPairing(ZeroconfPairing):
         if not self.accessories:
             await self.list_accessories_and_characteristics()
 
+        if isinstance(characteristics, set):
+            characteristics_set = characteristics
+        else:
+            characteristics_set = set(characteristics)
+
         url = "/characteristics?id=" + ",".join(
-            str(x[0]) + "." + str(x[1]) for x in set(characteristics)
+            f"{aid}.{iid}" for aid, iid in characteristics_set
         )
 
         response = await self.connection.get_json(url)

--- a/tests/test_ip_pairing.py
+++ b/tests/test_ip_pairing.py
@@ -150,6 +150,10 @@ async def test_put_characteristics_callbacks(pairing: IpPairing):
 
     assert characteristics[(1, 9)] == {"value": True}
 
+    characteristics = await pairing.get_characteristics({(1, 9)})
+
+    assert characteristics[(1, 9)] == {"value": True}
+
 
 async def test_subscribe(pairing: IpPairing):
     assert pairing.subscriptions == set()


### PR DESCRIPTION
- Add some missing typing

fixes home-assistant/core#103103

- coap: needed an subscriptable list
- ble: didn't care about order
- ip: didn't care about order and always converted to a set