### PR TITLE
Fix IP exceptions referencing the old host var

### DIFF
--- a/aiohomekit/controller/ip/pairing.py
+++ b/aiohomekit/controller/ip/pairing.py
@@ -146,18 +146,18 @@ class IpPairing(ZeroconfPairing):
                 last_connector_error, asyncio.TimeoutError
             ):
                 raise AccessoryDisconnectedError(
-                    f"Timeout while waiting for connection to device {connection.host}:{connection.port}"
+                    f"Timeout while waiting for connection to device {connection.hosts}:{connection.port}"
                 )
             # The exception name is included since otherwise the error message
             # is not very helpful as it could be something like `step 3`
             raise AccessoryDisconnectedError(
-                f"Error while connecting to device {connection.host}:{connection.port}: "
+                f"Error while connecting to device {connection.hosts}:{connection.port}: "
                 f"{last_connector_error} ({type(last_connector_error).__name__})"
             )
 
         if not connection.is_connected:
             raise AccessoryDisconnectedError(
-                f"Ensure connection returned but still not connected: {connection.host}:{connection.port}"
+                f"Ensure connection returned but still not connected: {connection.connected_host}:{connection.port}"
             )
 
         self._callback_availability_changed(True)

--- a/aiohomekit/controller/ip/pairing.py
+++ b/aiohomekit/controller/ip/pairing.py
@@ -157,7 +157,7 @@ class IpPairing(ZeroconfPairing):
 
         if not connection.is_connected:
             raise AccessoryDisconnectedError(
-                f"Ensure connection returned but still not connected: {connection.connected_host}:{connection.port}"
+                f"Ensure connection returned but still not connected: {connection.hosts}:{connection.port}"
             )
 
         self._callback_availability_changed(True)


### PR DESCRIPTION
We now have multi-ip support but when I refactored, I missed some old `.host` variables in the exception text