### PR TITLE
Recover CoAP pairing when remote device stops responding

### DIFF
--- a/aiohomekit/controller/coap/connection.py
+++ b/aiohomekit/controller/coap/connection.py
@@ -170,6 +170,10 @@ class EncryptionContext:
                 async with asyncio_timeout(timeout):
                     response = await self.coap_ctx.request(request).response
             except (NetworkError, asyncio.TimeoutError):
+                logger.debug("%s: Did not receive a reply; end of session.", self.uri)
+                if self.coap_ctx:
+                    await self.coap_ctx.shutdown()
+                    self.coap_ctx = None
                 raise AccessoryDisconnectedError("Request timeout")
 
             if response.code == Code.NOT_FOUND:


### PR DESCRIPTION
Prior to this change if a remote device stopped responding (e.g. packet loss) we would never recover - we'd just keep incrementing the encryption counter making it further and further away from the truth.

The only way to recover from this right now is to restart HA which obviously resets the encryption session.

This patch can't fix the buggy device, unstable network or packet loss that lead to a timeout in the first place but it can help things recover without needing a full HA restart.

Tested by a community member with a very unstable set of Nanoleaf devices (multiple devices go offline at same time, and with this patch they actually recover by themselves).