### PR TITLE
Bumping chacha20poly1305-reuseable to 0.12.1

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -427,77 +427,77 @@ docs = ["Sphinx (>=1.0)", "sphinx_rtd_theme", "sphinxcontrib-programoutput"]
 
 [[package]]
 name = "chacha20poly1305-reuseable"
-version = "0.12.0"
+version = "0.12.1"
 description = "ChaCha20Poly1305 that is reuseable for asyncio"
 optional = false
 python-versions = ">=3.8,<4.0"
 files = [
-    {file = "chacha20poly1305_reuseable-0.12.0-cp310-cp310-macosx_11_0_x86_64.whl", hash = "sha256:750d34f2a28dee10a97818ebcfba74a4b5323a13299de62eccdd4c7bb6d46d53"},
-    {file = "chacha20poly1305_reuseable-0.12.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:260978d0e18cd06b9f5e14de880229a1347c8bc079a38e4e7c7a9baa7f297f66"},
-    {file = "chacha20poly1305_reuseable-0.12.0-cp310-cp310-manylinux_2_17_i686.manylinux_2_5_i686.manylinux1_i686.manylinux2014_i686.whl", hash = "sha256:2efc2925aad9e791573333fa7e40efa54a51eda0df9dfccd0f17bd535f0e2e57"},
-    {file = "chacha20poly1305_reuseable-0.12.0-cp310-cp310-manylinux_2_17_x86_64.manylinux_2_5_x86_64.manylinux1_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9f153fdca4dbd93aabe9475200c847c0a9b8710573d8bcd7588ba4dab0ca06e6"},
-    {file = "chacha20poly1305_reuseable-0.12.0-cp310-cp310-manylinux_2_31_x86_64.whl", hash = "sha256:278a3098e4fd77f5f62012832922eda0ca061eb4b393f03b546db0d93c722a20"},
-    {file = "chacha20poly1305_reuseable-0.12.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:f26dfef3b7c4f14b505ba560138fb8518cb91ccba852d489c191cc6b089afaa6"},
-    {file = "chacha20poly1305_reuseable-0.12.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:44131bf6d997c1952f4e74f851ea653414543f43718ad7b6430674f112f2c5bf"},
-    {file = "chacha20poly1305_reuseable-0.12.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:490eb4e875659993223955a795ef86b3fa43c237ef5c161e3ebbd463fcd36a83"},
-    {file = "chacha20poly1305_reuseable-0.12.0-cp310-cp310-win32.whl", hash = "sha256:5bca6a125eb36757532b1193d362862e801b1df9ff40dfb24f71fa5f8b46eb43"},
-    {file = "chacha20poly1305_reuseable-0.12.0-cp310-cp310-win_amd64.whl", hash = "sha256:c2fef7a8362c2b8014dd1c35b8109bdaefbdcc76fa378161a82e78ab2e56ed7d"},
-    {file = "chacha20poly1305_reuseable-0.12.0-cp311-cp311-macosx_11_0_x86_64.whl", hash = "sha256:8a811ac8daccc236bd5cde4c4623215764ab7849fc265ba22862b09c9eeb8593"},
-    {file = "chacha20poly1305_reuseable-0.12.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:62eaf80660a9bfdc1ea4636745490b76815ecdae8653a7190a2b4aefc0eae71e"},
-    {file = "chacha20poly1305_reuseable-0.12.0-cp311-cp311-manylinux_2_17_i686.manylinux_2_5_i686.manylinux1_i686.manylinux2014_i686.whl", hash = "sha256:2aea40696aa747857ec5ba18311c7aaf1d133df32b54f516c5fbe91c9f674eb1"},
-    {file = "chacha20poly1305_reuseable-0.12.0-cp311-cp311-manylinux_2_17_x86_64.manylinux_2_5_x86_64.manylinux1_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bf4fb957dc9b16bc6fc26b8bb5b033cd745b62a06ec6fc6ff566b786437b1c06"},
-    {file = "chacha20poly1305_reuseable-0.12.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:79184e09ce1830ec998d3ad8dfb39ccc40d3ea4ce6980cc28315fe2bddeb6464"},
-    {file = "chacha20poly1305_reuseable-0.12.0-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:dd2d283323b5ac40f4cffb69a3dbaccc3d6bd94d98d7757acd8b7ab15e618ecb"},
-    {file = "chacha20poly1305_reuseable-0.12.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:9be4938dec30d187a28e34cb1a25def5b176b463bf4096b93148a443e4224dce"},
-    {file = "chacha20poly1305_reuseable-0.12.0-cp311-cp311-win32.whl", hash = "sha256:d5186f6ad2e86acfb9ee13d98e8e5df148c33bc2a55a99fbc8be9651c5525f10"},
-    {file = "chacha20poly1305_reuseable-0.12.0-cp311-cp311-win_amd64.whl", hash = "sha256:82f932d6c98b4ce21c256f549e80cac19bec5c7596332349ab9316305f030cbe"},
-    {file = "chacha20poly1305_reuseable-0.12.0-cp312-cp312-macosx_11_0_x86_64.whl", hash = "sha256:1cb7bc824854b01a459e20b535d76c55852b7b4738159e84330cb20d302495d5"},
-    {file = "chacha20poly1305_reuseable-0.12.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:60a299f5e5241fbffcdc20e100ecc84152bf1b8dcd9ffc7a40b465dcd0a6a517"},
-    {file = "chacha20poly1305_reuseable-0.12.0-cp312-cp312-manylinux_2_17_i686.manylinux_2_5_i686.manylinux1_i686.manylinux2014_i686.whl", hash = "sha256:8dcb15c798d8f84d984505156c6a682d2643cffeefea556221ec690f0fb24ef0"},
-    {file = "chacha20poly1305_reuseable-0.12.0-cp312-cp312-manylinux_2_17_x86_64.manylinux_2_5_x86_64.manylinux1_x86_64.manylinux2014_x86_64.whl", hash = "sha256:783ef26c562fc03a93fdc76b0e542b452f28dfb3aa675080045cb9299f6154fc"},
-    {file = "chacha20poly1305_reuseable-0.12.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:c716571a2de0701df8b6a104efaf24105e28ccddb6ed23cb971518b33550a1d1"},
-    {file = "chacha20poly1305_reuseable-0.12.0-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:b104648d0bb8340bc1b8bb53e628be14517b23eccabf0dcf4d5e0250a4f9f821"},
-    {file = "chacha20poly1305_reuseable-0.12.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:159f7923f5196ceb012bd686c96f881e66940e02c054ff9fc739d99f04168690"},
-    {file = "chacha20poly1305_reuseable-0.12.0-cp312-cp312-win32.whl", hash = "sha256:5230ad468f6ff7f7833247e0267d9d364216ea1cd5e5075d63ddad6864236ed3"},
-    {file = "chacha20poly1305_reuseable-0.12.0-cp312-cp312-win_amd64.whl", hash = "sha256:a210c5323f736c1003e3e7781355ec91103bccc3a85798425d3d3325d0a0bcf3"},
-    {file = "chacha20poly1305_reuseable-0.12.0-cp38-cp38-macosx_11_0_x86_64.whl", hash = "sha256:fa0e39cbb0cd5fd3b6b833a8ff8ffafc5053ddd54360b4760bfd41f922809934"},
-    {file = "chacha20poly1305_reuseable-0.12.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cd6ca9e23429202507d6f3bcdeba988ce53b1df7e1d45f48e056e877ed15ffe3"},
-    {file = "chacha20poly1305_reuseable-0.12.0-cp38-cp38-manylinux_2_17_i686.manylinux_2_5_i686.manylinux1_i686.manylinux2014_i686.whl", hash = "sha256:b53d122022d8da2c435f61b80dda6e5cc2d2f6b9ec89bab8a7ef7976b6b00ad7"},
-    {file = "chacha20poly1305_reuseable-0.12.0-cp38-cp38-manylinux_2_17_x86_64.manylinux_2_5_x86_64.manylinux1_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ef229a9619e6c890337a92eb0ee6aee4076a0bb215e3787051cb0b8e5f40f177"},
-    {file = "chacha20poly1305_reuseable-0.12.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:fbdd860ce4e603c35f9459c36054192336a8a7ecc162b7b254a5e0f41ffc76cc"},
-    {file = "chacha20poly1305_reuseable-0.12.0-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:86b46463307d246b6636803355b541f60b80a66496922a16e4dc4d7c02ad922a"},
-    {file = "chacha20poly1305_reuseable-0.12.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:fcae6e2c3ebb47562744dcb6f62144eaf84be94890bb98c7f752405ab4cd4386"},
-    {file = "chacha20poly1305_reuseable-0.12.0-cp38-cp38-win32.whl", hash = "sha256:e975ea57f4c0ca3013b82f5f678b09877167707f51b89a3f8243e0a17f125c25"},
-    {file = "chacha20poly1305_reuseable-0.12.0-cp38-cp38-win_amd64.whl", hash = "sha256:a7adfec441daf2a99225830e68649c290bd5d25a7f19ac316bcaed97d25dd09e"},
-    {file = "chacha20poly1305_reuseable-0.12.0-cp39-cp39-macosx_11_0_x86_64.whl", hash = "sha256:0c2559696a61d4caf4b805eacd8546cf4010bc6b3e6340be84816ac4d5fad388"},
-    {file = "chacha20poly1305_reuseable-0.12.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4e4ad7fc74ccb2304991d61edc7585e3c860c64393f6ff5e8ae9d0c81512db8f"},
-    {file = "chacha20poly1305_reuseable-0.12.0-cp39-cp39-manylinux_2_17_i686.manylinux_2_5_i686.manylinux1_i686.manylinux2014_i686.whl", hash = "sha256:d02d0217db191726aad22a5c1600ccd9d0e29158e1a34ec0d61f3f9e7fc7043d"},
-    {file = "chacha20poly1305_reuseable-0.12.0-cp39-cp39-manylinux_2_17_x86_64.manylinux_2_5_x86_64.manylinux1_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d2cacd00f388eb817a16a62831b4b3e6ec2511d46044db2e94b0e3c3d403c4b4"},
-    {file = "chacha20poly1305_reuseable-0.12.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:c1f4b34a868915e2fd478761e8836070cb0913b91769fa525f9ef1163cb4908d"},
-    {file = "chacha20poly1305_reuseable-0.12.0-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:9159ed775fee33a857188aac51c3e901d89a6e22c1ed5b906c271137897ecb61"},
-    {file = "chacha20poly1305_reuseable-0.12.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:dbd425f82b6fc5658428c4a813e4ed0500c621432d31df3c780d12ff92a7f5ff"},
-    {file = "chacha20poly1305_reuseable-0.12.0-cp39-cp39-win32.whl", hash = "sha256:3dd4a3c9863b4a9a18ba5a20402bf505aa220281ef02056042cceb587028b737"},
-    {file = "chacha20poly1305_reuseable-0.12.0-cp39-cp39-win_amd64.whl", hash = "sha256:0c1cdbf74c880d083212d54fe228d0398a7ed4d9827018a1b8145adb3dcf8632"},
-    {file = "chacha20poly1305_reuseable-0.12.0-pp310-pypy310_pp73-macosx_11_0_x86_64.whl", hash = "sha256:9493dc3d1f09539472a760a6365ad90296ef7c258edc4bef86703b6b1a7b5630"},
-    {file = "chacha20poly1305_reuseable-0.12.0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:53ae391d39de13364b596ef51f583ec2cc74ec37d04a743ce3253e0ffcbf6657"},
-    {file = "chacha20poly1305_reuseable-0.12.0-pp310-pypy310_pp73-manylinux_2_17_i686.manylinux_2_5_i686.manylinux1_i686.manylinux2014_i686.whl", hash = "sha256:a68ba1fbe6cc00951eb9cad99cce830793867b9940fa7e14e0326ff4eff3bb91"},
-    {file = "chacha20poly1305_reuseable-0.12.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux_2_5_x86_64.manylinux1_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c6b4d7d8d5562844757e93735cc9e6b651e64e9f3c77b55a6f24d310486a25bf"},
-    {file = "chacha20poly1305_reuseable-0.12.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:d104d495139c48b2d2d7e8f2eea48f843fbb201dfc018d89425870ac058177bf"},
-    {file = "chacha20poly1305_reuseable-0.12.0-pp38-pypy38_pp73-macosx_11_0_x86_64.whl", hash = "sha256:9b0011230f7f7a5b4fdfff3d4225c5f9d52dcbb08e21e32b2e4dd7d652efa745"},
-    {file = "chacha20poly1305_reuseable-0.12.0-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:76ea0eb896a0d3649d2f37480321bb8e731c553ed5eb65a5233a0bd855d04798"},
-    {file = "chacha20poly1305_reuseable-0.12.0-pp38-pypy38_pp73-manylinux_2_17_i686.manylinux_2_5_i686.manylinux1_i686.manylinux2014_i686.whl", hash = "sha256:816b725ad52eb85d2d3cf02403ac8a34c7937e8565f9e72aed7b7ef5eee9c5c3"},
-    {file = "chacha20poly1305_reuseable-0.12.0-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux_2_5_x86_64.manylinux1_x86_64.manylinux2014_x86_64.whl", hash = "sha256:871adad99cbfa50943f7e1e191ffce2c8db5009a278c0f2ac9910e91a3024314"},
-    {file = "chacha20poly1305_reuseable-0.12.0-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:1cbeb002a9de0ca1d509b6983f7ce14a982e7c89f6b60917c9869fd051dba4d4"},
-    {file = "chacha20poly1305_reuseable-0.12.0-pp39-pypy39_pp73-macosx_11_0_x86_64.whl", hash = "sha256:dc9a83183b5fed8f771c797ee90d7b44f6430f1fbf0daefa2809dad282923613"},
-    {file = "chacha20poly1305_reuseable-0.12.0-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d363fc0ab344c7faacab09490e51a8836de4a809fa81c918e2346452f7d7deac"},
-    {file = "chacha20poly1305_reuseable-0.12.0-pp39-pypy39_pp73-manylinux_2_17_i686.manylinux_2_5_i686.manylinux1_i686.manylinux2014_i686.whl", hash = "sha256:d1d47a4cbbdb67871f4726a31f3fa2d3a3c7e16dda7db9352924e69e4010a791"},
-    {file = "chacha20poly1305_reuseable-0.12.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux_2_5_x86_64.manylinux1_x86_64.manylinux2014_x86_64.whl", hash = "sha256:49f05675f5dde3f055cdd83da841dcefd23affed0eb2b278382661bc022a5334"},
-    {file = "chacha20poly1305_reuseable-0.12.0-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:10f55c73185d3b8799f6183c609b6b33db6cfbb0891b1450eba8120a9e758416"},
-    {file = "chacha20poly1305_reuseable-0.12.0.tar.gz", hash = "sha256:238a1d5af6473a8ed249e6ddad327190b3567a673ad54766c9cb2da5c78a4c9b"},
+    {file = "chacha20poly1305_reuseable-0.12.1-cp310-cp310-macosx_11_0_x86_64.whl", hash = "sha256:15a8e9522038914f785fc1483310d49e4213c9896037d0ff03db0dd0a2323672"},
+    {file = "chacha20poly1305_reuseable-0.12.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a697d7e9a8285bef1804130edf537f487d0ebf1a1b78ac67178808ebe9b0b099"},
+    {file = "chacha20poly1305_reuseable-0.12.1-cp310-cp310-manylinux_2_17_i686.manylinux_2_5_i686.manylinux1_i686.manylinux2014_i686.whl", hash = "sha256:687538314a6bae5a0cecf83a18fdcd31cc94fccd26bc68e0a90ec4ba2a464b22"},
+    {file = "chacha20poly1305_reuseable-0.12.1-cp310-cp310-manylinux_2_17_x86_64.manylinux_2_5_x86_64.manylinux1_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d5c92aa5ad1c2f544479fecc0003c50d7fa72240c97bdafd3388dae6d7c29eaf"},
+    {file = "chacha20poly1305_reuseable-0.12.1-cp310-cp310-manylinux_2_31_x86_64.whl", hash = "sha256:d369686388a4b43f1eea0e2a9d717375d8e5cb4717f953ab036dcc1061208e58"},
+    {file = "chacha20poly1305_reuseable-0.12.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:dd0986f26c38616e6fe93d2465f69fa0d8a299e95be4e1a9786ef9402923d330"},
+    {file = "chacha20poly1305_reuseable-0.12.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:8a87414ca3d6da1a7b7303564cddcf0d6a6ac1a8cd60a839c3a105134fdefdd5"},
+    {file = "chacha20poly1305_reuseable-0.12.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:f7d93eca59e08949f28ded9e1b96f95fb5c53d7696c17d0f7207a764a8ff5266"},
+    {file = "chacha20poly1305_reuseable-0.12.1-cp310-cp310-win32.whl", hash = "sha256:a2522f0429da6ca5d2fbc09ec4f0841550a0e18e0db297b864e7e953f4b0deb9"},
+    {file = "chacha20poly1305_reuseable-0.12.1-cp310-cp310-win_amd64.whl", hash = "sha256:81b3634dad5ccff099763c74f8426c408bc6588363a1af8bd2575ef539bd9d53"},
+    {file = "chacha20poly1305_reuseable-0.12.1-cp311-cp311-macosx_11_0_x86_64.whl", hash = "sha256:a35d4318919c4f890c31d97cc09746bf1d4695ca755babf05f39c1b19f4da002"},
+    {file = "chacha20poly1305_reuseable-0.12.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:871b057a62f1e5da31d4ba3d2e52ad4b2b97653b72a6a84af6ba9b82e240e128"},
+    {file = "chacha20poly1305_reuseable-0.12.1-cp311-cp311-manylinux_2_17_i686.manylinux_2_5_i686.manylinux1_i686.manylinux2014_i686.whl", hash = "sha256:167abfab75d4f459e2ecc21f7e487931b6845b558219a2a23e9095efa827ff73"},
+    {file = "chacha20poly1305_reuseable-0.12.1-cp311-cp311-manylinux_2_17_x86_64.manylinux_2_5_x86_64.manylinux1_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6197f56ef97ec51a96dbf5876f1938487e1db2afe7997729427400fe33700d2f"},
+    {file = "chacha20poly1305_reuseable-0.12.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:394062aa5072e5e226fb25c2508441556a239aebb37ce09b15ebb730a8f685ba"},
+    {file = "chacha20poly1305_reuseable-0.12.1-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:5c548d69d0efd4c7f28afb6e848fad23a45f8e42d47e13516a80090121ad7c9b"},
+    {file = "chacha20poly1305_reuseable-0.12.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:a6e6b49f72e02d84bab442c10dd1c7cff813752d111efa6a165d2263d0453c2c"},
+    {file = "chacha20poly1305_reuseable-0.12.1-cp311-cp311-win32.whl", hash = "sha256:f32a2a5abcc794649385294feeefc8f20c7e03ad26a7f0deaf751a795520498e"},
+    {file = "chacha20poly1305_reuseable-0.12.1-cp311-cp311-win_amd64.whl", hash = "sha256:742dea78f8e3299ac0a4b636bc31e05094b72de436cdebc3e1ef55b4da90c463"},
+    {file = "chacha20poly1305_reuseable-0.12.1-cp312-cp312-macosx_11_0_x86_64.whl", hash = "sha256:a1e59072c12557384e7916b8061ceaae0c9e416b569758fea4730e4c19d35216"},
+    {file = "chacha20poly1305_reuseable-0.12.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:444777c3097d11c768bb7ed2fc4545e50a7024c6d0d23412a260b98a0a73a7e9"},
+    {file = "chacha20poly1305_reuseable-0.12.1-cp312-cp312-manylinux_2_17_i686.manylinux_2_5_i686.manylinux1_i686.manylinux2014_i686.whl", hash = "sha256:739b21d069527713ae9e68c2332775f080322b566524069f3a9d2a0fcafeba75"},
+    {file = "chacha20poly1305_reuseable-0.12.1-cp312-cp312-manylinux_2_17_x86_64.manylinux_2_5_x86_64.manylinux1_x86_64.manylinux2014_x86_64.whl", hash = "sha256:72c8b9f96183878452507d35811ad53b25eb9f5edab3c448a9fa15f9faccd93b"},
+    {file = "chacha20poly1305_reuseable-0.12.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:6bb82b0dcc6bb65d1cfcabcf11ac34e3e7f8989235367d1a605178fb98bc4ce7"},
+    {file = "chacha20poly1305_reuseable-0.12.1-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:8c216a071c8171231553ff804d60fe93c0c4219694b3d7dbda43274d94d92424"},
+    {file = "chacha20poly1305_reuseable-0.12.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:19d993f001fdccff442d2afed1775b9c4b4355c26ee8766e2c725bc7371fd931"},
+    {file = "chacha20poly1305_reuseable-0.12.1-cp312-cp312-win32.whl", hash = "sha256:e35af9637529efd014cf34527433a2515df4b4fe69886b0bdcbe9328afd90a3b"},
+    {file = "chacha20poly1305_reuseable-0.12.1-cp312-cp312-win_amd64.whl", hash = "sha256:4b29da5307627e64c4a20170f5bee408e2d84ad7cda8ea8266e69d7a8c9b5182"},
+    {file = "chacha20poly1305_reuseable-0.12.1-cp38-cp38-macosx_11_0_x86_64.whl", hash = "sha256:4a475385b4a48fc69453851e62671cc5713eec82c712cb653436508ea5008297"},
+    {file = "chacha20poly1305_reuseable-0.12.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dd39c22826657b665b4f646ef346342e47b87ae77da9774d8b626055d293a196"},
+    {file = "chacha20poly1305_reuseable-0.12.1-cp38-cp38-manylinux_2_17_i686.manylinux_2_5_i686.manylinux1_i686.manylinux2014_i686.whl", hash = "sha256:5f80e3b5adabd3b2f01107e46740a4e4c3a8638912a4548edc32c06d3a515a43"},
+    {file = "chacha20poly1305_reuseable-0.12.1-cp38-cp38-manylinux_2_17_x86_64.manylinux_2_5_x86_64.manylinux1_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c9301a585e75c1adff8f8b318873cc999b7b0a9c75ac59aca1e20f1355018aba"},
+    {file = "chacha20poly1305_reuseable-0.12.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:1b4f6a58f274595f96354e79c162f1aba9137105ca8629b4851242dfa5196c39"},
+    {file = "chacha20poly1305_reuseable-0.12.1-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:55c737a96398a33642f97a56f93db0f1731171ba98945d5f2d17e95c84a021e9"},
+    {file = "chacha20poly1305_reuseable-0.12.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:a9ec58d17b1fbf081dff982fc1770cfd046fba4b40aca6854d24c503e839eeaf"},
+    {file = "chacha20poly1305_reuseable-0.12.1-cp38-cp38-win32.whl", hash = "sha256:0cfe515ab58a4bade63d3deedb7ef0b01ee4fdadb7d3867748ff75d05f3b23d6"},
+    {file = "chacha20poly1305_reuseable-0.12.1-cp38-cp38-win_amd64.whl", hash = "sha256:f4c47cb4be085ad0bca5909deee7f4a2fd3b75f02761e419fc886163aae63be0"},
+    {file = "chacha20poly1305_reuseable-0.12.1-cp39-cp39-macosx_11_0_x86_64.whl", hash = "sha256:c9e0a0d8c0f5d52780e0e1689ebb1e9a84aa7d2671feea3851dfb23b28fcfe1f"},
+    {file = "chacha20poly1305_reuseable-0.12.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5723c81e5c62990258e6db2294a3ecb421821b132e274055c3742c3d03af3783"},
+    {file = "chacha20poly1305_reuseable-0.12.1-cp39-cp39-manylinux_2_17_i686.manylinux_2_5_i686.manylinux1_i686.manylinux2014_i686.whl", hash = "sha256:40e36e18f907ad621d2c589967a5ae65ae5af765da279313958339810111c0c5"},
+    {file = "chacha20poly1305_reuseable-0.12.1-cp39-cp39-manylinux_2_17_x86_64.manylinux_2_5_x86_64.manylinux1_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8fa57e5084a8f178445600c916c44052901885006544d1126ced18a55fa6dc03"},
+    {file = "chacha20poly1305_reuseable-0.12.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:33e10528e9638ac229d035f471460d281448aca32575ae6b23ed84baf2627ee5"},
+    {file = "chacha20poly1305_reuseable-0.12.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:feab4f476d1bd323be822d82ed5dab34cc885f0c30caaca02a7037d12b7d2eac"},
+    {file = "chacha20poly1305_reuseable-0.12.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:5258e5ed2df04a5c1989aab727fa45e352dc1af162789c075c1baf798c614d86"},
+    {file = "chacha20poly1305_reuseable-0.12.1-cp39-cp39-win32.whl", hash = "sha256:827f10b7deb330b2764dce4c16d1db5115c412a6369269a8e211697654cdbba8"},
+    {file = "chacha20poly1305_reuseable-0.12.1-cp39-cp39-win_amd64.whl", hash = "sha256:1d15b8ceb0e03081dbaccff762bab436b78905a8fd895f8c0f4c6c10ea50183e"},
+    {file = "chacha20poly1305_reuseable-0.12.1-pp310-pypy310_pp73-macosx_11_0_x86_64.whl", hash = "sha256:994eb234ca10df88ec60a1db6689eef42d4032e5947b5942c11304a427e79023"},
+    {file = "chacha20poly1305_reuseable-0.12.1-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6fd87b20925df3dc195229c94d4df50e560831a26f86b34af4d6ae575725ea3c"},
+    {file = "chacha20poly1305_reuseable-0.12.1-pp310-pypy310_pp73-manylinux_2_17_i686.manylinux_2_5_i686.manylinux1_i686.manylinux2014_i686.whl", hash = "sha256:44c2ec3bd9aea2214666c3442824b717632ba46c8afedc194a9c9e91664e58d4"},
+    {file = "chacha20poly1305_reuseable-0.12.1-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux_2_5_x86_64.manylinux1_x86_64.manylinux2014_x86_64.whl", hash = "sha256:76ff52546ef2652581c9cced2b08668c889f8cd8ca3356e59bc8a2513571a6a9"},
+    {file = "chacha20poly1305_reuseable-0.12.1-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:e38395bc4f85b94415dd2855e98237c6437833654a761307309e6c54e86501f6"},
+    {file = "chacha20poly1305_reuseable-0.12.1-pp38-pypy38_pp73-macosx_11_0_x86_64.whl", hash = "sha256:e37fbf9ffd41ddf14ee966529e95c933d39d2eec5d9deebbb572176dccc6ea42"},
+    {file = "chacha20poly1305_reuseable-0.12.1-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:22e0722905d7cfa87dd26f23c54c65ce222f6cfa6b81ec4b9db584c234587725"},
+    {file = "chacha20poly1305_reuseable-0.12.1-pp38-pypy38_pp73-manylinux_2_17_i686.manylinux_2_5_i686.manylinux1_i686.manylinux2014_i686.whl", hash = "sha256:cc9148d4b8a3615dec398bf7f0451009782f79b6f7050dff400363563756a4ea"},
+    {file = "chacha20poly1305_reuseable-0.12.1-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux_2_5_x86_64.manylinux1_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8da6f724050b7870c2f3a82c68385a155221166a3666de436728d0bdac555e05"},
+    {file = "chacha20poly1305_reuseable-0.12.1-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:3e2f8f969b4d3facf15e780867843ecd0990e729424dac17bad63b6de7440fd1"},
+    {file = "chacha20poly1305_reuseable-0.12.1-pp39-pypy39_pp73-macosx_11_0_x86_64.whl", hash = "sha256:322650588a464135bdfd4c397e598099fd6749acae3503b99991cf0884b18f54"},
+    {file = "chacha20poly1305_reuseable-0.12.1-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:721319faac787eb8135d436d24ba36cfbfba9e876796c559b928b4c3fb7f1e12"},
+    {file = "chacha20poly1305_reuseable-0.12.1-pp39-pypy39_pp73-manylinux_2_17_i686.manylinux_2_5_i686.manylinux1_i686.manylinux2014_i686.whl", hash = "sha256:fd554491775fcbc0697e9d461966d569970cdc9c9b5e8113a41338619fe8020e"},
+    {file = "chacha20poly1305_reuseable-0.12.1-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux_2_5_x86_64.manylinux1_x86_64.manylinux2014_x86_64.whl", hash = "sha256:93405b12f4126b92d6b7b5ef05c5d1d0fef1c33372a6f1392cdc6a91afb20c8d"},
+    {file = "chacha20poly1305_reuseable-0.12.1-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:c3bd840dbc08204f4b0bf86370b39c527b3a094d8662c9cfc7dcba14aee114c2"},
+    {file = "chacha20poly1305_reuseable-0.12.1.tar.gz", hash = "sha256:c1ca3de2c78eb87ac006d975729e0b9032ff31597e3c112e78268f4cd431fd6a"},
 ]
 
 [package.dependencies]
-cryptography = ">=36.0.2"
+cryptography = ">=42.0.0"
 
 [[package]]
 name = "click"
@@ -604,47 +604,56 @@ toml = ["tomli"]
 
 [[package]]
 name = "cryptography"
-version = "41.0.7"
+version = "42.0.2"
 description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "cryptography-41.0.7-cp37-abi3-macosx_10_12_universal2.whl", hash = "sha256:3c78451b78313fa81607fa1b3f1ae0a5ddd8014c38a02d9db0616133987b9cdf"},
-    {file = "cryptography-41.0.7-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:928258ba5d6f8ae644e764d0f996d61a8777559f72dfeb2eea7e2fe0ad6e782d"},
-    {file = "cryptography-41.0.7-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5a1b41bc97f1ad230a41657d9155113c7521953869ae57ac39ac7f1bb471469a"},
-    {file = "cryptography-41.0.7-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:841df4caa01008bad253bce2a6f7b47f86dc9f08df4b433c404def869f590a15"},
-    {file = "cryptography-41.0.7-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:5429ec739a29df2e29e15d082f1d9ad683701f0ec7709ca479b3ff2708dae65a"},
-    {file = "cryptography-41.0.7-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:43f2552a2378b44869fe8827aa19e69512e3245a219104438692385b0ee119d1"},
-    {file = "cryptography-41.0.7-cp37-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:af03b32695b24d85a75d40e1ba39ffe7db7ffcb099fe507b39fd41a565f1b157"},
-    {file = "cryptography-41.0.7-cp37-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:49f0805fc0b2ac8d4882dd52f4a3b935b210935d500b6b805f321addc8177406"},
-    {file = "cryptography-41.0.7-cp37-abi3-win32.whl", hash = "sha256:f983596065a18a2183e7f79ab3fd4c475205b839e02cbc0efbbf9666c4b3083d"},
-    {file = "cryptography-41.0.7-cp37-abi3-win_amd64.whl", hash = "sha256:90452ba79b8788fa380dfb587cca692976ef4e757b194b093d845e8d99f612f2"},
-    {file = "cryptography-41.0.7-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:079b85658ea2f59c4f43b70f8119a52414cdb7be34da5d019a77bf96d473b960"},
-    {file = "cryptography-41.0.7-pp310-pypy310_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:b640981bf64a3e978a56167594a0e97db71c89a479da8e175d8bb5be5178c003"},
-    {file = "cryptography-41.0.7-pp310-pypy310_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:e3114da6d7f95d2dee7d3f4eec16dacff819740bbab931aff8648cb13c5ff5e7"},
-    {file = "cryptography-41.0.7-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:d5ec85080cce7b0513cfd233914eb8b7bbd0633f1d1703aa28d1dd5a72f678ec"},
-    {file = "cryptography-41.0.7-pp38-pypy38_pp73-macosx_10_12_x86_64.whl", hash = "sha256:7a698cb1dac82c35fcf8fe3417a3aaba97de16a01ac914b89a0889d364d2f6be"},
-    {file = "cryptography-41.0.7-pp38-pypy38_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:37a138589b12069efb424220bf78eac59ca68b95696fc622b6ccc1c0a197204a"},
-    {file = "cryptography-41.0.7-pp38-pypy38_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:68a2dec79deebc5d26d617bfdf6e8aab065a4f34934b22d3b5010df3ba36612c"},
-    {file = "cryptography-41.0.7-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:09616eeaef406f99046553b8a40fbf8b1e70795a91885ba4c96a70793de5504a"},
-    {file = "cryptography-41.0.7-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:48a0476626da912a44cc078f9893f292f0b3e4c739caf289268168d8f4702a39"},
-    {file = "cryptography-41.0.7-pp39-pypy39_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:c7f3201ec47d5207841402594f1d7950879ef890c0c495052fa62f58283fde1a"},
-    {file = "cryptography-41.0.7-pp39-pypy39_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:c5ca78485a255e03c32b513f8c2bc39fedb7f5c5f8535545bdc223a03b24f248"},
-    {file = "cryptography-41.0.7-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:d6c391c021ab1f7a82da5d8d0b3cee2f4b2c455ec86c8aebbc84837a631ff309"},
-    {file = "cryptography-41.0.7.tar.gz", hash = "sha256:13f93ce9bea8016c253b34afc6bd6a75993e5c40672ed5405a9c832f0d4a00bc"},
+    {file = "cryptography-42.0.2-cp37-abi3-macosx_10_12_universal2.whl", hash = "sha256:701171f825dcab90969596ce2af253143b93b08f1a716d4b2a9d2db5084ef7be"},
+    {file = "cryptography-42.0.2-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:61321672b3ac7aade25c40449ccedbc6db72c7f5f0fdf34def5e2f8b51ca530d"},
+    {file = "cryptography-42.0.2-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ea2c3ffb662fec8bbbfce5602e2c159ff097a4631d96235fcf0fb00e59e3ece4"},
+    {file = "cryptography-42.0.2-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3b15c678f27d66d247132cbf13df2f75255627bcc9b6a570f7d2fd08e8c081d2"},
+    {file = "cryptography-42.0.2-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:8e88bb9eafbf6a4014d55fb222e7360eef53e613215085e65a13290577394529"},
+    {file = "cryptography-42.0.2-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:a047682d324ba56e61b7ea7c7299d51e61fd3bca7dad2ccc39b72bd0118d60a1"},
+    {file = "cryptography-42.0.2-cp37-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:36d4b7c4be6411f58f60d9ce555a73df8406d484ba12a63549c88bd64f7967f1"},
+    {file = "cryptography-42.0.2-cp37-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:a00aee5d1b6c20620161984f8ab2ab69134466c51f58c052c11b076715e72929"},
+    {file = "cryptography-42.0.2-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:b97fe7d7991c25e6a31e5d5e795986b18fbbb3107b873d5f3ae6dc9a103278e9"},
+    {file = "cryptography-42.0.2-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:5fa82a26f92871eca593b53359c12ad7949772462f887c35edaf36f87953c0e2"},
+    {file = "cryptography-42.0.2-cp37-abi3-win32.whl", hash = "sha256:4b063d3413f853e056161eb0c7724822a9740ad3caa24b8424d776cebf98e7ee"},
+    {file = "cryptography-42.0.2-cp37-abi3-win_amd64.whl", hash = "sha256:841ec8af7a8491ac76ec5a9522226e287187a3107e12b7d686ad354bb78facee"},
+    {file = "cryptography-42.0.2-cp39-abi3-macosx_10_12_universal2.whl", hash = "sha256:55d1580e2d7e17f45d19d3b12098e352f3a37fe86d380bf45846ef257054b242"},
+    {file = "cryptography-42.0.2-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:28cb2c41f131a5758d6ba6a0504150d644054fd9f3203a1e8e8d7ac3aea7f73a"},
+    {file = "cryptography-42.0.2-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b9097a208875fc7bbeb1286d0125d90bdfed961f61f214d3f5be62cd4ed8a446"},
+    {file = "cryptography-42.0.2-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:44c95c0e96b3cb628e8452ec060413a49002a247b2b9938989e23a2c8291fc90"},
+    {file = "cryptography-42.0.2-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2f9f14185962e6a04ab32d1abe34eae8a9001569ee4edb64d2304bf0d65c53f3"},
+    {file = "cryptography-42.0.2-cp39-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:09a77e5b2e8ca732a19a90c5bca2d124621a1edb5438c5daa2d2738bfeb02589"},
+    {file = "cryptography-42.0.2-cp39-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:ad28cff53f60d99a928dfcf1e861e0b2ceb2bc1f08a074fdd601b314e1cc9e0a"},
+    {file = "cryptography-42.0.2-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:130c0f77022b2b9c99d8cebcdd834d81705f61c68e91ddd614ce74c657f8b3ea"},
+    {file = "cryptography-42.0.2-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:fa3dec4ba8fb6e662770b74f62f1a0c7d4e37e25b58b2bf2c1be4c95372b4a33"},
+    {file = "cryptography-42.0.2-cp39-abi3-win32.whl", hash = "sha256:3dbd37e14ce795b4af61b89b037d4bc157f2cb23e676fa16932185a04dfbf635"},
+    {file = "cryptography-42.0.2-cp39-abi3-win_amd64.whl", hash = "sha256:8a06641fb07d4e8f6c7dda4fc3f8871d327803ab6542e33831c7ccfdcb4d0ad6"},
+    {file = "cryptography-42.0.2-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:087887e55e0b9c8724cf05361357875adb5c20dec27e5816b653492980d20380"},
+    {file = "cryptography-42.0.2-pp310-pypy310_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:a7ef8dd0bf2e1d0a27042b231a3baac6883cdd5557036f5e8df7139255feaac6"},
+    {file = "cryptography-42.0.2-pp310-pypy310_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:4383b47f45b14459cab66048d384614019965ba6c1a1a141f11b5a551cace1b2"},
+    {file = "cryptography-42.0.2-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:fbeb725c9dc799a574518109336acccaf1303c30d45c075c665c0793c2f79a7f"},
+    {file = "cryptography-42.0.2-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:320948ab49883557a256eab46149df79435a22d2fefd6a66fe6946f1b9d9d008"},
+    {file = "cryptography-42.0.2-pp39-pypy39_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:5ef9bc3d046ce83c4bbf4c25e1e0547b9c441c01d30922d812e887dc5f125c12"},
+    {file = "cryptography-42.0.2-pp39-pypy39_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:52ed9ebf8ac602385126c9a2fe951db36f2cb0c2538d22971487f89d0de4065a"},
+    {file = "cryptography-42.0.2-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:141e2aa5ba100d3788c0ad7919b288f89d1fe015878b9659b307c9ef867d3a65"},
+    {file = "cryptography-42.0.2.tar.gz", hash = "sha256:e0ec52ba3c7f1b7d813cd52649a5b3ef1fc0d433219dc8c93827c57eab6cf888"},
 ]
 
 [package.dependencies]
-cffi = ">=1.12"
+cffi = {version = ">=1.12", markers = "platform_python_implementation != \"PyPy\""}
 
 [package.extras]
 docs = ["sphinx (>=5.3.0)", "sphinx-rtd-theme (>=1.1.1)"]
-docstest = ["pyenchant (>=1.6.11)", "sphinxcontrib-spelling (>=4.0.1)", "twine (>=1.12.0)"]
+docstest = ["pyenchant (>=1.6.11)", "readme-renderer", "sphinxcontrib-spelling (>=4.0.1)"]
 nox = ["nox"]
-pep8test = ["black", "check-sdist", "mypy", "ruff"]
+pep8test = ["check-sdist", "click", "mypy", "ruff"]
 sdist = ["build"]
 ssh = ["bcrypt (>=3.1.5)"]
-test = ["pretend", "pytest (>=6.2.0)", "pytest-benchmark", "pytest-cov", "pytest-xdist"]
+test = ["certifi", "pretend", "pytest (>=6.2.0)", "pytest-benchmark", "pytest-cov", "pytest-xdist"]
 test-randomorder = ["pytest-randomly"]
 
 [[package]]
@@ -1734,4 +1743,4 @@ ifaddr = ">=0.1.7"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "80b72c6c8a3961c6c5107ccdb29caeb9fedfc4afb1ca78fd9b02b4dfb10deb40"
+content-hash = "6a6e1b91ebcfff95a78b888d746f5145a90b31648cd1ca70f4a7497703d3028d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ zeroconf = ">=0.128.4"
 commentjson = "^0.9.0"
 aiocoap = ">=0.4.5"
 bleak = ">=0.19.0"
-chacha20poly1305-reuseable = ">=0.0.4"
+chacha20poly1305-reuseable = ">=0.12.1"
 bleak-retry-connector = ">=2.9.0"
 orjson = ">=3.7.8"
 async-timeout = {version = ">=4.0.2", python = "<3.11"}


### PR DESCRIPTION
This also indirectly bumps cryptography to >=42.0.0.

This fixes CI with newer versions of cryptography.