### PR TITLE
Small speed up to fetch characteristic values

### DIFF
--- a/aiohomekit/model/characteristics/characteristic.py
+++ b/aiohomekit/model/characteristics/characteristic.py
@@ -192,7 +192,14 @@ class Characteristic:
 
     @property
     def value(self) -> Any:
-        extra_data = characteristics.get(self.type, {})
+        """Get the value of the characteristic.
+
+        If the characteristic is a tlv8, decodes the struct
+
+        If the characteristic is an enum, returns the enum value
+        """
+        if not (extra_data := characteristics.get(self.type)):
+            return self._value
 
         if self.format == CharacteristicFormats.tlv8:
             new_val = base64.b64decode(self._value)


### PR DESCRIPTION
We can avoid most of the body of this function for the common case.  We call this a lot when adding entities

<img width="1501" alt="Screenshot 2024-02-22 at 2 15 09 AM" src="https://github.com/Jc2k/aiohomekit/assets/663432/74e464de-b492-4bde-bee2-8f9c04bf5e72">
