### PR TITLE
Avoid creating tasks to process zeroconf updates

### DIFF
--- a/aiohomekit/controller/abstract.py
+++ b/aiohomekit/controller/abstract.py
@@ -149,7 +149,7 @@ class AbstractPairing(metaclass=ABCMeta):
         return self._accessories_state.state_num
 
     @abstractmethod
-    async def _process_disconnected_events(self):
+    def _process_disconnected_events(self):
         """Process any disconnected events that are available."""
 
     def _callback_listeners(self, event):
@@ -203,7 +203,7 @@ class AbstractPairing(metaclass=ABCMeta):
                     "%s: Disconnected event notification received; Triggering catch-up poll",
                     self.name,
                 )
-                async_create_task(self._process_disconnected_events())
+                self._process_disconnected_events()
 
         self.description = description
 

--- a/aiohomekit/controller/ble/pairing.py
+++ b/aiohomekit/controller/ble/pairing.py
@@ -596,7 +596,7 @@ class BlePairing(AbstractPairing):
             self._derive = derive
 
     def _process_disconnected_events(self) -> None:
-        async_create_task(self._async_process_disconnected_events)
+        async_create_task(self._async_process_disconnected_events())
 
     async def _async_process_disconnected_events(self) -> None:
         """Handle disconnected events seen from the advertisement."""

--- a/aiohomekit/controller/ble/pairing.py
+++ b/aiohomekit/controller/ble/pairing.py
@@ -595,7 +595,10 @@ class BlePairing(AbstractPairing):
             self._session_id = session_id
             self._derive = derive
 
-    async def _process_disconnected_events(self) -> None:
+    def _process_disconnected_events(self) -> None:
+        async_create_task(self._async_process_disconnected_events)
+
+    async def _async_process_disconnected_events(self) -> None:
         """Handle disconnected events seen from the advertisement."""
         if not self._tried_to_connect_once:
             # We never tried connected to the accessory, so we don't need to
@@ -664,7 +667,7 @@ class BlePairing(AbstractPairing):
                 self.name,
                 data,
             )
-            async_create_task(self._process_disconnected_events())
+            self._process_disconnected_events()
             return
 
         if not self.description:
@@ -741,7 +744,7 @@ class BlePairing(AbstractPairing):
             self.name,
             data,
         )
-        async_create_task(self._process_disconnected_events())
+        self._process_disconnected_events()
 
     def _async_get_service_signature_char(self) -> Characteristic | None:
         """Get the service signature characteristic."""

--- a/aiohomekit/controller/coap/pairing.py
+++ b/aiohomekit/controller/coap/pairing.py
@@ -172,7 +172,7 @@ class CoAPPairing(ZeroconfPairing):
         )
         self._callback_and_save_config_changed(config_num)
 
-    async def _process_disconnected_events(self):
+    def _process_disconnected_events(self):
         """Process any events that happened while we were disconnected.
 
         We don't disconnect in COAP so there is no need to do anything here.

--- a/aiohomekit/controller/ip/pairing.py
+++ b/aiohomekit/controller/ip/pairing.py
@@ -426,7 +426,7 @@ class IpPairing(ZeroconfPairing):
         )
         self._callback_and_save_config_changed(self.config_num)
 
-    async def _process_disconnected_events(self):
+    def _process_disconnected_events(self):
         """Process any events that happened while we were disconnected.
 
         We don't disconnect in IP so there is no need to do anything here.


### PR DESCRIPTION
Since ip pairing and coap pairings do nothing in _process_disconnected_events, make it a normal function instead and have the ble pairing create tasks as needed