### PR TITLE
Fix IP controller not reconnecting right away

### DIFF
--- a/aiohomekit/controller/ip/connection.py
+++ b/aiohomekit/controller/ip/connection.py
@@ -86,6 +86,7 @@ class InsecureHomeKitProtocol(asyncio.Protocol):
 
     def connection_lost(self, exception):
         self.connection._connection_lost(exception)
+        self._cancel_pending_requests()
 
     def _handle_timeout(self, fut: asyncio.Future[Any]) -> None:
         """Handle a timeout."""
@@ -151,6 +152,9 @@ class InsecureHomeKitProtocol(asyncio.Protocol):
         return False
 
     def close(self):
+        self._cancel_pending_requests()
+
+    def _cancel_pending_requests(self) -> None:
         # If the connection is closed then any pending callbacks will never
         # fire, so set them to an error state.
         while self.result_cbs:
@@ -557,19 +561,19 @@ class HomeKitConnection:
         Called by a Protocol instance when eof_received happens.
         """
         logger.debug("Connection %r lost.", self)
-
-        if not self.closing:
-            self._start_connector()
-
-        if self.closing:
-            self.closed = True
-
+        # Clear the transport and protocol right away
+        # as otherwise _start_connector will see them and
+        # think we are still connected.
         self.transport = None
         self.protocol = None
+        if self.closing:
+            self.closed = True
+        else:
+            self._start_connector()
 
     async def _connect_once(self) -> None:
         """_connect_once must only ever be called from _reconnect to ensure its done with a lock."""
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
 
         logger.debug("Attempting connection to %s:%s", self.hosts, self.port)
 
@@ -597,6 +601,7 @@ class HomeKitConnection:
                 raise TimeoutError("Timeout") from last_exception
             raise ConnectionError(str(last_exception)) from last_exception
 
+        logger.debug("Connected established to %s:%s", self.hosts, self.port)
         # set keep-alive on the socket to ensure we detect dropped connections
         # since we don't send keep-alive packets ourselves
         sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
@@ -616,7 +621,9 @@ class HomeKitConnection:
             self.host_header = f"Host: [{connected_host}]"
         else:
             self.host_header = f"Host: {connected_host}"
+
         if self.owner:
+            logger.debug("Connection made to %s:%s", self.hosts, self.port)
             await self.owner.connection_made(False)
 
     async def _reconnect(self) -> None:
@@ -736,6 +743,11 @@ class SecureHomeKitConnection(HomeKitConnection):
                 pass
 
         await super()._connect_once()
+        logger.debug(
+            "SecureHomeKitConnection established to %s:%s",
+            self.connected_host,
+            self.port,
+        )
 
         state_machine = get_session_keys(self.pairing_data)
 

--- a/tests/test_ip_pairing.py
+++ b/tests/test_ip_pairing.py
@@ -130,21 +130,10 @@ async def test_reconnect_soon_on_device_reboot(pairing: IpPairing):
         side_effect=asyncio.TimeoutError,
     ):
         pairing.connection.protocol.connection_lost(OSError("Connection reset by peer"))
-        await asyncio.sleep(0)
-        assert not pairing.connection.is_connected
-        assert not pairing.is_available
-
-        for _ in range(3):
-            pairing._async_description_update(None)
-            # ensure the callback has a chance to run and create _connector
-            await asyncio.sleep(0)
-            with pytest.raises(asyncio.TimeoutError):
-                await asyncio.wait_for(
-                    asyncio.shield(pairing.connection._connector), timeout=0.2
-                )
-            assert not pairing.connection.is_connected
-
-    pairing._async_description_update(None)
+    
+    await asyncio.sleep(0)
+    assert not pairing.connection.is_connected
+    assert not pairing.is_available
     await asyncio.wait_for(pairing.connection._connector, timeout=0.5)
     assert pairing.connection.is_connected
     assert pairing.is_available

--- a/tests/test_ip_pairing.py
+++ b/tests/test_ip_pairing.py
@@ -100,7 +100,7 @@ async def test_reconnect_soon_after_device_is_offline_for_a_bit(pairing: IpPairi
         for _ in range(3):
             pairing._async_description_update(None)
             # ensure the callback has a chance to run and create _connector
-            await asyncio.sleep(0)  
+            await asyncio.sleep(0)
             with pytest.raises(asyncio.TimeoutError):
                 await asyncio.wait_for(
                     asyncio.shield(pairing.connection._connector), timeout=0.2
@@ -115,7 +115,6 @@ async def test_reconnect_soon_after_device_is_offline_for_a_bit(pairing: IpPairi
     characteristics = await pairing.get_characteristics([(1, 9)])
 
     assert characteristics[(1, 9)] == {"value": False}
-
 
 
 async def test_reconnect_soon_on_device_reboot(pairing: IpPairing):
@@ -138,7 +137,7 @@ async def test_reconnect_soon_on_device_reboot(pairing: IpPairing):
         for _ in range(3):
             pairing._async_description_update(None)
             # ensure the callback has a chance to run and create _connector
-            await asyncio.sleep(0)  
+            await asyncio.sleep(0)
             with pytest.raises(asyncio.TimeoutError):
                 await asyncio.wait_for(
                     asyncio.shield(pairing.connection._connector), timeout=0.2
@@ -153,6 +152,7 @@ async def test_reconnect_soon_on_device_reboot(pairing: IpPairing):
     characteristics = await pairing.get_characteristics([(1, 9)])
 
     assert characteristics[(1, 9)] == {"value": False}
+
 
 async def test_put_characteristics(pairing: IpPairing):
     characteristics = await pairing.put_characteristics([(1, 9, True)])

--- a/tests/test_ip_pairing.py
+++ b/tests/test_ip_pairing.py
@@ -130,7 +130,7 @@ async def test_reconnect_soon_on_device_reboot(pairing: IpPairing):
         side_effect=asyncio.TimeoutError,
     ):
         pairing.connection.protocol.connection_lost(OSError("Connection reset by peer"))
-    
+
     await asyncio.sleep(0)
     assert not pairing.connection.is_connected
     assert not pairing.is_available

--- a/tests/test_ip_pairing.py
+++ b/tests/test_ip_pairing.py
@@ -99,9 +99,8 @@ async def test_reconnect_soon_after_device_is_offline_for_a_bit(pairing: IpPairi
 
         for _ in range(3):
             pairing._async_description_update(None)
-            await asyncio.sleep(
-                0
-            )  # ensure the callback has a chance to run and create _connector
+            # ensure the callback has a chance to run and create _connector
+            await asyncio.sleep(0)  
             with pytest.raises(asyncio.TimeoutError):
                 await asyncio.wait_for(
                     asyncio.shield(pairing.connection._connector), timeout=0.2
@@ -117,6 +116,43 @@ async def test_reconnect_soon_after_device_is_offline_for_a_bit(pairing: IpPairi
 
     assert characteristics[(1, 9)] == {"value": False}
 
+
+
+async def test_reconnect_soon_on_device_reboot(pairing: IpPairing):
+    characteristics = await pairing.get_characteristics([(1, 9)])
+
+    assert characteristics[(1, 9)] == {"value": False}
+
+    assert pairing.connection.is_connected
+    assert pairing.is_available
+
+    with mock.patch(
+        "aiohomekit.controller.ip.connection.HomeKitConnection._connect_once",
+        side_effect=asyncio.TimeoutError,
+    ):
+        pairing.connection.protocol.connection_lost(OSError("Connection reset by peer"))
+        await asyncio.sleep(0)
+        assert not pairing.connection.is_connected
+        assert not pairing.is_available
+
+        for _ in range(3):
+            pairing._async_description_update(None)
+            # ensure the callback has a chance to run and create _connector
+            await asyncio.sleep(0)  
+            with pytest.raises(asyncio.TimeoutError):
+                await asyncio.wait_for(
+                    asyncio.shield(pairing.connection._connector), timeout=0.2
+                )
+            assert not pairing.connection.is_connected
+
+    pairing._async_description_update(None)
+    await asyncio.wait_for(pairing.connection._connector, timeout=0.5)
+    assert pairing.connection.is_connected
+    assert pairing.is_available
+
+    characteristics = await pairing.get_characteristics([(1, 9)])
+
+    assert characteristics[(1, 9)] == {"value": False}
 
 async def test_put_characteristics(pairing: IpPairing):
     characteristics = await pairing.put_characteristics([(1, 9, True)])


### PR DESCRIPTION
There were two problems that prevented the IP transport from reconnecting

1. When the connection was lost, _start_connector would not try to reconnect because self.transport and self.protocol were still set which meant the connection was not full torn down and it thought it was still connected. This is fixed by clearing transport and protocol before calling _start_connector.  This meant we would never reconnect until a poll attempt which restarted the connector.

2. If a request was inflight the connection would get re-established and than the concurrency lock would prevent the pair-verify from happening. This is fixed by resolving all the futures that are waiting when the connection is lost.