### PR TITLE
Fix race when during timeout of IP connection request

### DIFF
--- a/aiohomekit/controller/ip/connection.py
+++ b/aiohomekit/controller/ip/connection.py
@@ -159,7 +159,8 @@ class InsecureHomeKitProtocol(asyncio.Protocol):
         # fire, so set them to an error state.
         while self.result_cbs:
             result = self.result_cbs.pop(0)
-            result.set_exception(AccessoryDisconnectedError("Connection closed"))
+            if not result.done():
+                result.set_exception(AccessoryDisconnectedError("Connection closed"))
 
 
 class SecureHomeKitProtocol(InsecureHomeKitProtocol):


### PR DESCRIPTION
If the requests hits th 30s timeout, but responds or times out at just the right time before the during the connection teardown, the future will already be resolved.