### PR TITLE
Move supports_subscribe to AbstractPairing

### DIFF
--- a/aiohomekit/controller/abstract.py
+++ b/aiohomekit/controller/abstract.py
@@ -83,6 +83,7 @@ class AbstractPairing(metaclass=ABCMeta):
         self.config_changed_listeners: set[Callable[[int], None]] = set()
         self._accessories_state: AccessoriesState | None = None
         self._shutdown = False
+        self.supports_subscribe = True
 
         self.id = pairing_data["AccessoryPairingID"]
         self._pairing_data = pairing_data

--- a/aiohomekit/controller/ip/pairing.py
+++ b/aiohomekit/controller/ip/pairing.py
@@ -86,8 +86,6 @@ class IpPairing(ZeroconfPairing):
         """
         self.pairing_data = pairing_data
         self.connection = SecureHomeKitConnection(self, self.pairing_data)
-        self.supports_subscribe = True
-
         super().__init__(controller, pairing_data)
 
     @property


### PR DESCRIPTION
We have a check to see if subscribe is broken but checking it depends on the pairing type. Make sure all pairings support this.

related issue https://github.com/home-assistant/core/issues/124099