### PR TITLE
Implement zerocopy writes for the encrypted protocol

### DIFF
--- a/aiohomekit/controller/controller.py
+++ b/aiohomekit/controller/controller.py
@@ -72,9 +72,9 @@ class Controller(AbstractController):
         self._tasks = AsyncExitStack()
 
     async def _async_register_backend(self, controller: AbstractController) -> None:
-        self.transports[controller.transport_type] = (
-            await self._tasks.enter_async_context(controller)
-        )
+        self.transports[
+            controller.transport_type
+        ] = await self._tasks.enter_async_context(controller)
 
     async def async_start(self) -> None:
         if IP_TRANSPORT_SUPPORTED or self._async_zeroconf_instance:

--- a/aiohomekit/controller/controller.py
+++ b/aiohomekit/controller/controller.py
@@ -72,9 +72,9 @@ class Controller(AbstractController):
         self._tasks = AsyncExitStack()
 
     async def _async_register_backend(self, controller: AbstractController) -> None:
-        self.transports[
-            controller.transport_type
-        ] = await self._tasks.enter_async_context(controller)
+        self.transports[controller.transport_type] = (
+            await self._tasks.enter_async_context(controller)
+        )
 
     async def async_start(self) -> None:
         if IP_TRANSPORT_SUPPORTED or self._async_zeroconf_instance:

--- a/aiohomekit/controller/ip/connection.py
+++ b/aiohomekit/controller/ip/connection.py
@@ -47,7 +47,7 @@ from aiohomekit.protocol import get_session_keys
 from aiohomekit.protocol.tlv import TLV
 from aiohomekit.utils import async_create_task, asyncio_timeout
 
-PACK_UNSIGNED_SHORT = Struct(">H").pack
+PACK_UNSIGNED_SHORT_LITTLE = Struct("<H").pack
 
 
 if TYPE_CHECKING:
@@ -197,7 +197,7 @@ class SecureHomeKitProtocol(InsecureHomeKitProtocol):
         while len(payload) > 0:
             current = payload[:1024]
             payload = payload[1024:]
-            len_bytes = PACK_UNSIGNED_SHORT(len(current))
+            len_bytes = PACK_UNSIGNED_SHORT_LITTLE(len(current))
             buffer.append(len_bytes)
             buffer.append(
                 self.encryptor.encrypt(len_bytes, PACK_NONCE(self.c2a_counter), current)

--- a/aiohomekit/controller/ip/connection.py
+++ b/aiohomekit/controller/ip/connection.py
@@ -18,7 +18,8 @@ from struct import Struct
 import asyncio
 import logging
 import socket
-from typing import TYPE_CHECKING, Any, Iterable
+from typing import TYPE_CHECKING, Any
+from collections.abc import Iterable
 
 import aiohappyeyeballs
 from async_interrupt import interrupt

--- a/aiohomekit/controller/ip/connection.py
+++ b/aiohomekit/controller/ip/connection.py
@@ -100,9 +100,9 @@ class InsecureHomeKitProtocol(asyncio.Protocol):
 
     async def send_bytes(self, payload: bytes) -> HttpResponse:
         """Send bytes to the device."""
-        return await self.send_lines((payload,))
+        return await self._send_lines((payload,))
 
-    async def send_lines(self, payload: Iterable[bytes]) -> HttpResponse:
+    async def _send_lines(self, payload: Iterable[bytes]) -> HttpResponse:
         """Send bytes to the device."""
         if self.transport.is_closing():
             # FIXME: It would be nice to try and wait for the reconnect in future.
@@ -204,7 +204,7 @@ class SecureHomeKitProtocol(InsecureHomeKitProtocol):
             )
             self.c2a_counter += 1
 
-        return await self.send_lines(buffer)
+        return await self._send_lines(buffer)
 
     def data_received(self, data: bytes) -> None:
         """

--- a/aiohomekit/controller/ip/connection.py
+++ b/aiohomekit/controller/ip/connection.py
@@ -14,12 +14,13 @@
 # limitations under the License.
 #
 from __future__ import annotations
-from struct import Struct
+
 import asyncio
+from collections.abc import Iterable
 import logging
 import socket
+from struct import Struct
 from typing import TYPE_CHECKING, Any
-from collections.abc import Iterable
 
 import aiohappyeyeballs
 from async_interrupt import interrupt

--- a/tests/test_ip_pairing.py
+++ b/tests/test_ip_pairing.py
@@ -157,7 +157,7 @@ async def test_put_characteristics_cancelled(pairing: IpPairing):
     characteristics = await pairing.put_characteristics([(1, 9, True)])
     characteristics = await pairing.get_characteristics([(1, 9)])
 
-    with mock.patch.object(pairing.connection.transport, "write"):
+    with mock.patch.object(pairing.connection.transport, "writelines"):
         task = asyncio.create_task(pairing.put_characteristics([(1, 9, False)]))
         await asyncio.sleep(0)
         for future in pairing.connection.protocol.result_cbs:


### PR DESCRIPTION
With Python 3.12+ and later `transport.writelines` is implemented as [`sendmsg(..., IOV_MAX)`](https://github.com/python/cpython/issues/91166) which allows us to avoid joining the bytes and sending them in one go.

Older Python will effectively do the same thing we do now `b"".join(...)`