### PR TITLE
Fix pairings being loaded before transports

### DIFF
--- a/aiohomekit/__main__.py
+++ b/aiohomekit/__main__.py
@@ -52,12 +52,6 @@ async def get_controller(args: argparse.Namespace) -> AsyncIterator[Controller]:
         char_cache=CharacteristicCacheFile(charmap_path),
     )
 
-    try:
-        controller.load_data(args.file)
-    except Exception:
-        logger.exception(f"Error while loading {args.file}")
-        raise SystemExit
-
     async with zeroconf:
         listener = ZeroconfServiceListener()
         browser = AsyncServiceBrowser(
@@ -70,6 +64,11 @@ async def get_controller(args: argparse.Namespace) -> AsyncIterator[Controller]:
         )
 
         async with controller:
+            try:
+                controller.load_data(args.file)
+            except Exception:
+                logger.exception(f"Error while loading {args.file}")
+                raise SystemExit
             yield controller
 
         await browser.async_cancel()


### PR DESCRIPTION
This fixes an issue I observed locally, where running `aiohomekitctl` with any existing IP pairing would throw an error:

```
controller.py:0185 ERROR Skipped pairing: Transport IP not supported. See setup.py for required dependencies.
```

After tracing, I discovered this is because the pairings were loaded before the transports, and moving the load_data call to this new location seemed to have fixed it for me.