### PR TITLE
Modernize lint workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
 
     - name: Run pyupgrade
       shell: bash
-      run: poetry run find aiohomekit tests -name '*.py' -exec python -m pyupgrade --py310-plus {} + && git diff --exit-code
+      run: poetry run find aiohomekit tests -name '*.py' -exec python -m pyupgrade --py39-plus {} + && git diff --exit-code
 
     - name: Run isort
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,37 +15,14 @@ jobs:
     - name: Check out code from GitHub
       uses: actions/checkout@v2
 
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+    - name: Install poetry
+      run: pipx install poetry
+
+    - name: Set up Python 3.11
+      uses: actions/setup-python@v5
       with:
         python-version: 3.11
-
-    - name: Get full Python version
-      id: full-python-version
-      shell: bash
-      run: echo ::set-output name=version::$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")
-
-    - name: Install poetry
-      shell: bash
-      run: |
-        python -m pip install -U pip poetry
-        echo "$HOME/.poetry/bin:$PATH" >> $GITHUB_PATH
-
-    - name: Configure poetry
-      shell: bash
-      run: poetry config virtualenvs.in-project true
-
-    - name: Set up cache
-      uses: actions/cache@v2
-      id: cache
-      with:
-        path: .venv
-        key: venv-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('**/poetry.lock') }}
-
-    - name: Ensure cache is healthy
-      if: steps.cache.outputs.cache-hit == 'true'
-      shell: bash
-      run: poetry run pip --version >/dev/null 2>&1 || rm -rf .venv
+        cache: 'poetry'
 
     - name: Install dependencies
       shell: bash
@@ -53,7 +30,7 @@ jobs:
 
     - name: Run pyupgrade
       shell: bash
-      run: poetry run find aiohomekit tests -name '*.py' -exec python -m pyupgrade --py39-plus {} + && git diff --exit-code
+      run: poetry run find aiohomekit tests -name '*.py' -exec python -m pyupgrade --py310-plus {} + && git diff --exit-code
 
     - name: Run isort
       shell: bash


### PR DESCRIPTION
Fixes
```
lintYour workflow is using a version of actions/cache that is scheduled for deprecation, actions/cache@v2. Please update your workflow to use either v3 or v4 of actions/cache to avoid interruptions. Learn more: https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-downShow more
--
lintThe `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

[lint](https://github.com/Jc2k/aiohomekit/actions/runs/13598166056/job/38019457811)
Your workflow is using a version of actions/cache that is scheduled for deprecation, actions/cache@v2. Please update your workflow to use either v3 or v4 of actions/cache to avoid interruptions. Learn more: https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down
lint
The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```