### PR TITLE
Fix _update_subscriptions - checking characteristic's aid and iid existence #1

### DIFF
--- a/aiohomekit/controller/ip/pairing.py
+++ b/aiohomekit/controller/ip/pairing.py
@@ -397,11 +397,12 @@ class IpPairing(ZeroconfPairing):
             if response:
                 # An empty body is a success response
                 for row in response.get("characteristics", []):
-                    status[(row["aid"], row["iid"])] = {
-                        "status": row["status"],
-                        "description": to_status_code(row["status"]).description,
-                    }
-
+                    if "aid" in row and "iid" in row:
+                      status[(row["aid"], row["iid"])] = {
+                          "status": row["status"],
+                          "description": to_status_code(row["status"]).description,
+                      }
+        
         return status
 
     async def async_populate_accessories_state(

--- a/aiohomekit/controller/ip/pairing.py
+++ b/aiohomekit/controller/ip/pairing.py
@@ -398,11 +398,11 @@ class IpPairing(ZeroconfPairing):
                 # An empty body is a success response
                 for row in response.get("characteristics", []):
                     if "aid" in row and "iid" in row:
-                      status[(row["aid"], row["iid"])] = {
-                          "status": row["status"],
-                          "description": to_status_code(row["status"]).description,
-                      }
-        
+                        status[(row["aid"], row["iid"])] = {
+                            "status": row["status"],
+                            "description": to_status_code(row["status"]).description,
+                        }
+
         return status
 
     async def async_populate_accessories_state(


### PR DESCRIPTION
Somfy TaHoma switch homekit controller /characteristics response is: {'status': 0}
As consequence, KeyError: 'aid' is raised breaking characteristics subscriptions (poll works, push/ev does not). Fix checks for existence of aid and iid.
Once fix is applied, push/event works perfectly on Somfy TaHoma switch.

Initial error is
```
Error doing job: Task exception was never retrieved (None)
Traceback (most recent call last):
  File "/srv/homeassistant/lib/python3.13/site-packages/aiohomekit/controller/ip/pairing.py", line 359, in subscribe
    return await self._update_subscriptions(characteristics, True)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/srv/homeassistant/lib/python3.13/site-packages/aiohomekit/controller/ip/pairing.py", line 401, in _update_subscriptions
    status[(row["aid"], row["iid"])] = {
            ~~~^^^^^^^
KeyError: 'aid'
