### PR TITLE
Ensure connection is always shutdown when removing a pairing

### DIFF
--- a/aiohomekit/controller/abstract.py
+++ b/aiohomekit/controller/abstract.py
@@ -320,6 +320,7 @@ class AbstractPairing(metaclass=ABCMeta):
     async def _shutdown_if_primary_pairing_removed(self, pairingId: str) -> None:
         """Shutdown the connection if the primary pairing was removed."""
         if pairingId == self._pairing_data.get("iOSPairingId"):
+            logger.debug("%s: Primary pairing removed; shutting down", self.name)
             await self.shutdown()
 
     async def shutdown(self) -> None:
@@ -329,6 +330,7 @@ class AbstractPairing(metaclass=ABCMeta):
         the pairing is removed or the controller is shutdown.
         """
         self._shutdown = True
+        logger.debug("%s: Shutting down", self.name)
         await self.close()
 
     def _callback_availability_changed(self, available: bool) -> None:

--- a/aiohomekit/controller/ip/connection.py
+++ b/aiohomekit/controller/ip/connection.py
@@ -316,6 +316,7 @@ class HomeKitConnection:
         if self.is_connected:
             return False
         self.closing = False
+        logger.debug("%s: Starting connector", self.name)
         self._start_connector()
         return True
 
@@ -349,6 +350,7 @@ class HomeKitConnection:
         """
         if not self._connector:
             return
+        logger.debug("%s: Stopping connector", self.name)
         self._connector.cancel("Stop connector")
         # Wait for the connector but do not propagate the CancelledError
         # since the connector will be canceled when the connection is closed.

--- a/aiohomekit/controller/ip/pairing.py
+++ b/aiohomekit/controller/ip/pairing.py
@@ -501,7 +501,9 @@ class IpPairing(ZeroconfPairing):
             (TLV.kTLVType_Identifier, pairingId.encode("utf-8")),
         ]
 
+        logger.debug("Removing pairing with id %s", pairingId)
         data = dict(await self.connection.post_tlv("/pairings", request_tlv))
+        logger.debug("Remove pairing response: %s", data)
 
         if data.get(TLV.kTLVType_State, TLV.M2) != TLV.M2:
             raise InvalidError("Unexpected state after removing pairing request")

--- a/aiohomekit/controller/ip/pairing.py
+++ b/aiohomekit/controller/ip/pairing.py
@@ -503,7 +503,6 @@ class IpPairing(ZeroconfPairing):
 
         logger.debug("Removing pairing with id %s", pairingId)
         data = dict(await self.connection.post_tlv("/pairings", request_tlv))
-        logger.debug("Remove pairing response: %s", data)
 
         if data.get(TLV.kTLVType_State, TLV.M2) != TLV.M2:
             raise InvalidError("Unexpected state after removing pairing request")

--- a/aiohomekit/controller/ip/pairing.py
+++ b/aiohomekit/controller/ip/pairing.py
@@ -501,7 +501,6 @@ class IpPairing(ZeroconfPairing):
             (TLV.kTLVType_Identifier, pairingId.encode("utf-8")),
         ]
 
-        logger.debug("Removing pairing with id %s", pairingId)
         data = dict(await self.connection.post_tlv("/pairings", request_tlv))
 
         if data.get(TLV.kTLVType_State, TLV.M2) != TLV.M2:

--- a/aiohomekit/controller/ip/pairing.py
+++ b/aiohomekit/controller/ip/pairing.py
@@ -549,4 +549,5 @@ class IpPairing(ZeroconfPairing):
         super()._async_description_update(description)
 
         # If we are not connected, or are in the process of reconnecting, hasten the process
-        self.connection.reconnect_soon()
+        if not self._shutdown:
+            self.connection.reconnect_soon()


### PR DESCRIPTION
- If anything fails, we should still explictly shutdown the connection.
- If the device gets rediscovered after shutdown via `_async_description_update`, don't reconnect

fixes #343