### PR TITLE
Handle unknown HAP status codes gracefully

### DIFF
--- a/aiohomekit/controller/ip/pairing.py
+++ b/aiohomekit/controller/ip/pairing.py
@@ -63,11 +63,12 @@ def format_characteristic_list(
     # Handle global error status first - set defaults for all requested characteristics
     if "status" in data and data["status"] != 0:
         # Device returned a global error status
-        try:
-            description = to_status_code(data["status"]).description
-        except ValueError:
-            # Unknown status code
+        status_code = to_status_code(data["status"])
+        # For unknown codes, include the actual code in the description
+        if status_code == HapStatusCode.UNKNOWN:
             description = f"Unknown error code: {data['status']}"
+        else:
+            description = status_code.description
 
         logger.debug(
             "Device returned error status %s (%s) for characteristics request",
@@ -93,11 +94,11 @@ def format_characteristic_list(
         if "status" in c and c["status"] == 0:
             del c["status"]
         if "status" in c and c["status"] != 0:
-            try:
-                c["description"] = to_status_code(c["status"]).description
-            except ValueError:
-                # Unknown status code
+            status_code = to_status_code(c["status"])
+            if status_code == HapStatusCode.UNKNOWN:
                 c["description"] = f"Unknown error code: {c['status']}"
+            else:
+                c["description"] = status_code.description
         tmp[key] = c
 
     return tmp

--- a/aiohomekit/protocol/statuscodes.py
+++ b/aiohomekit/protocol/statuscodes.py
@@ -14,7 +14,11 @@
 # limitations under the License.
 #
 
+import logging
+
 from aiohomekit.enum import EnumWithDescription
+
+logger = logging.getLogger(__name__)
 
 
 class HapStatusCode(EnumWithDescription):
@@ -37,11 +41,19 @@ class HapStatusCode(EnumWithDescription):
     INVALID_VALUE = -70410, "Accessory received an invalid value in a write request."
     INSUFFICIENT_AUTH = -70411, "Insufficient Authorization."
     NOT_ALLOWED_IN_CURRENT_STATE = -70412, "Not allowed in current state"
+    # Special status for unknown/undefined error codes
+    UNKNOWN = -1, "Unknown or undefined status code"
 
 
 def to_status_code(status_code: int) -> HapStatusCode:
     # Some HAP implementations return positive values for error code (myq)
-    return HapStatusCode(abs(status_code) * -1)
+    normalized = abs(status_code) * -1
+    try:
+        return HapStatusCode(normalized)
+    except ValueError:
+        # Return UNKNOWN for undefined status codes
+        logger.debug("Unknown HAP status code: %s (normalized: %s)", status_code, normalized)
+        return HapStatusCode.UNKNOWN
 
 
 class _HapBleStatusCodes:

--- a/tests/test_controller_ip_pairing.py
+++ b/tests/test_controller_ip_pairing.py
@@ -207,18 +207,27 @@ def test_format_characteristic_list_global_error_with_partial_data() -> None:
 
 
 def test_format_characteristic_list_unknown_status_codes() -> None:
-    """Test handling of unknown/undefined status codes."""
-    # Test global unknown error
-    response = {"status": -99999}
+    """Test handling of unknown/undefined status codes including -6 from Nanoleaf."""
+    # Test status -6 (from Nanoleaf devices)
+    response = {"status": -6}
     requested = {(1, 2), (1, 3)}
 
     result = format_characteristic_list(response, requested)
 
     assert len(result) == 2
+    assert result[(1, 2)]["status"] == -6
+    assert result[(1, 2)]["description"] == "Unknown error code: -6"
+    assert result[(1, 3)]["status"] == -6
+    assert result[(1, 3)]["description"] == "Unknown error code: -6"
+
+    # Test another unknown error
+    response = {"status": -99999}
+    requested = {(1, 2)}
+
+    result = format_characteristic_list(response, requested)
+
     assert result[(1, 2)]["status"] == -99999
     assert result[(1, 2)]["description"] == "Unknown error code: -99999"
-    assert result[(1, 3)]["status"] == -99999
-    assert result[(1, 3)]["description"] == "Unknown error code: -99999"
 
     # Test individual unknown error
     response = {


### PR DESCRIPTION
# Handle unknown HAP status codes gracefully

## Summary

Fixes crashes when accessories return undefined HAP status codes (e.g., Nanoleaf's `-6`). Previously, `to_status_code()` would raise `ValueError` for unknown codes, causing HomeKit Controller setup failures.

## Changes

- Added `HapStatusCode.UNKNOWN` enum value for undefined status codes
- Modified `to_status_code()` to return `UNKNOWN` instead of raising `ValueError`
- Added debug logging to track unknown status codes for future investigation

## Related Issues

- https://github.com/home-assistant/core/issues/152259
- Fixes Nanoleaf device setup failures with `ValueError: -6 is not a valid HapStatusCode`