### PR TITLE
Fix struct.error when parsing corrupted BLE manufacturer data

### DIFF
--- a/aiohomekit/controller/ble/manufacturer_data.py
+++ b/aiohomekit/controller/ble/manufacturer_data.py
@@ -37,6 +37,9 @@ class HomeKitAdvertisement(AbstractDescription):
         if data[0] != HOMEKIT_ADVERTISEMENT_TYPE:
             raise ValueError("Not a HomeKit device")
 
+        if len(data) < 19:
+            raise ValueError("HomeKit advertisement data too short")
+
         sf = data[2]
         device_id = ":".join(data[3:9].hex()[0 + i : 2 + i] for i in range(0, 12, 2)).lower()
         acid, gsn, cn, cv = UNPACK_HHBB(data[9:15])

--- a/tests/test_controller_ble_manufacturer_data.py
+++ b/tests/test_controller_ble_manufacturer_data.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import pytest
+
+from aiohomekit.controller.ble.manufacturer_data import HomeKitAdvertisement
+
+
+def test_manufacturer_data_too_short() -> None:
+    """Test that short manufacturer data raises appropriate error."""
+    # Valid HomeKit advertisement type but buffer too short (less than 19 bytes)
+    short_data = b"\x06\x00\x00\x01\x02\x03\x04\x05\x06"  # Only 9 bytes
+
+    with pytest.raises(ValueError, match="HomeKit advertisement data too short"):
+        HomeKitAdvertisement.from_manufacturer_data(
+            name="Test", address="00:00:00:00:00:00", manufacturer_data={76: short_data}
+        )
+
+
+def test_manufacturer_data_almost_enough() -> None:
+    """Test with exactly 18 bytes (one less than required)."""
+    almost_data = b"\x06" + b"\x00" * 17  # 18 bytes total
+
+    with pytest.raises(ValueError, match="HomeKit advertisement data too short"):
+        HomeKitAdvertisement.from_manufacturer_data(
+            name="Test", address="00:00:00:00:00:00", manufacturer_data={76: almost_data}
+        )
+
+
+def test_manufacturer_data_exactly_enough() -> None:
+    """Test with exactly 19 bytes (minimum required)."""
+    valid_data = (
+        b"\x06\x00\x00\x01\x02\x03\x04\x05\x06\x07\x08\x00\x00\x00\x00\x00\x11\x22\x33"  # 19 bytes total
+    )
+
+    result = HomeKitAdvertisement.from_manufacturer_data(
+        name="Test", address="00:00:00:00:00:00", manufacturer_data={76: valid_data}
+    )
+
+    assert result is not None
+    assert result.address == "00:00:00:00:00:00"
+    assert result.name == "Test"


### PR DESCRIPTION
## Summary
- Fixes #480: `struct.error: unpack requires a buffer of 6 bytes` crash
- Added buffer size validation before unpacking HomeKit BLE advertisement data
- Prevents crashes when receiving malformed or truncated Bluetooth advertisements
- Raises a descriptive `ValueError` instead of letting `struct.unpack` fail
- Added comprehensive tests for various buffer sizes (too short, almost enough, exactly enough)
- Ensures the buffer has at least 19 bytes as required by the HomeKit BLE advertisement format