### PR TITLE
Stop using the deprecated event_loop fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -82,7 +82,7 @@ def mock_asynczeroconf():
 
 
 @pytest.fixture
-async def controller_and_unpaired_accessory(request, mock_asynczeroconf, event_loop, id_factory):
+async def controller_and_unpaired_accessory(request, mock_asynczeroconf, id_factory):
     available_port = next_available_port()
 
     config_file = tempfile.NamedTemporaryFile(delete=False)
@@ -133,7 +133,7 @@ async def controller_and_unpaired_accessory(request, mock_asynczeroconf, event_l
 
 
 @pytest.fixture
-async def controller_and_paired_accessory(request, event_loop, mock_asynczeroconf, id_factory):
+async def controller_and_paired_accessory(request, mock_asynczeroconf, id_factory):
     available_port = next_available_port()
 
     config_file = tempfile.NamedTemporaryFile(delete=False)
@@ -224,7 +224,7 @@ async def pairing(controller_and_paired_accessory):
 
 
 @pytest.fixture
-async def pairings(request, controller_and_paired_accessory, event_loop):
+async def pairings(request, controller_and_paired_accessory):
     """Returns a pairing of pairngs."""
     left = controller_and_paired_accessory.aliases["alias"]
 


### PR DESCRIPTION
https://github.com/pytest-dev/pytest-asyncio/pull/1106