### PR TITLE
Fix BLE advertisement parsing for older Eve gen1 devices

### DIFF
--- a/aiohomekit/controller/ble/manufacturer_data.py
+++ b/aiohomekit/controller/ble/manufacturer_data.py
@@ -37,13 +37,16 @@ class HomeKitAdvertisement(AbstractDescription):
         if data[0] != HOMEKIT_ADVERTISEMENT_TYPE:
             raise ValueError("Not a HomeKit device")
 
-        if len(data) < 19:
+        # Minimum size is 15 bytes for the basic fields
+        # Some devices (like Eve gen1) may not include the setup_hash
+        if len(data) < 15:
             raise ValueError("HomeKit advertisement data too short")
 
         sf = data[2]
         device_id = ":".join(data[3:9].hex()[0 + i : 2 + i] for i in range(0, 12, 2)).lower()
         acid, gsn, cn, cv = UNPACK_HHBB(data[9:15])
-        sh = data[15:19]
+        # Setup hash is optional - only present in data >= 19 bytes
+        sh = data[15:19] if len(data) >= 19 else b""
 
         return cls(
             name=name,

--- a/tests/test_controller_ble_manufacturer_data.py
+++ b/tests/test_controller_ble_manufacturer_data.py
@@ -7,7 +7,7 @@ from aiohomekit.controller.ble.manufacturer_data import HomeKitAdvertisement
 
 def test_manufacturer_data_too_short() -> None:
     """Test that short manufacturer data raises appropriate error."""
-    # Valid HomeKit advertisement type but buffer too short (less than 19 bytes)
+    # Valid HomeKit advertisement type but buffer too short (less than 15 bytes)
     short_data = b"\x06\x00\x00\x01\x02\x03\x04\x05\x06"  # Only 9 bytes
 
     with pytest.raises(ValueError, match="HomeKit advertisement data too short"):
@@ -16,18 +16,22 @@ def test_manufacturer_data_too_short() -> None:
         )
 
 
-def test_manufacturer_data_almost_enough() -> None:
-    """Test with exactly 18 bytes (one less than required)."""
-    almost_data = b"\x06" + b"\x00" * 17  # 18 bytes total
+def test_manufacturer_data_without_setup_hash() -> None:
+    """Test with 15 bytes (no setup hash - valid for older devices)."""
+    data_no_hash = b"\x06\x00\x00\x01\x02\x03\x04\x05\x06\x07\x08\x00\x00\x00\x00"  # 15 bytes total
 
-    with pytest.raises(ValueError, match="HomeKit advertisement data too short"):
-        HomeKitAdvertisement.from_manufacturer_data(
-            name="Test", address="00:00:00:00:00:00", manufacturer_data={76: almost_data}
-        )
+    result = HomeKitAdvertisement.from_manufacturer_data(
+        name="Test", address="00:00:00:00:00:00", manufacturer_data={76: data_no_hash}
+    )
+
+    assert result is not None
+    assert result.address == "00:00:00:00:00:00"
+    assert result.name == "Test"
+    assert result.setup_hash == b""  # No setup hash
 
 
-def test_manufacturer_data_exactly_enough() -> None:
-    """Test with exactly 19 bytes (minimum required)."""
+def test_manufacturer_data_with_setup_hash() -> None:
+    """Test with exactly 19 bytes (includes setup hash)."""
     valid_data = (
         b"\x06\x00\x00\x01\x02\x03\x04\x05\x06\x07\x08\x00\x00\x00\x00\x00\x11\x22\x33"  # 19 bytes total
     )
@@ -39,3 +43,4 @@ def test_manufacturer_data_exactly_enough() -> None:
     assert result is not None
     assert result.address == "00:00:00:00:00:00"
     assert result.name == "Test"
+    assert result.setup_hash == b"\x00\x11\x22\x33"  # Has setup hash


### PR DESCRIPTION
## Problem
PR #500 fixed issue #480 (struct.error crash) by requiring 19-byte BLE advertisements, but this broke Eve Thermo gen1 and Eve Room gen1 devices that only send 15-byte advertisements without the setup_hash field.

## Solution
- Reduced minimum advertisement size from 19 to 15 bytes (the actual required minimum) as aiohomekit can still work without the setup hash.
- Made setup_hash field (bytes 15-19) optional, defaulting to empty bytes when absent
- Updated tests to verify both 15-byte (no hash) and 19-byte (with hash) advertisements work
- Maintains protection against corrupted data (<15 bytes) while supporting older devices

Fixes: home-assistant/core#152674