### PR TITLE
Handle lark exceptions from json decoding failures

### DIFF
--- a/aiohomekit/hkjson.py
+++ b/aiohomekit/hkjson.py
@@ -20,9 +20,10 @@ from typing import Any
 
 import commentjson
 import orjson
+from lark.exceptions import LarkError
 
 JSON_ENCODE_EXCEPTIONS = (TypeError, ValueError)
-JSON_DECODE_EXCEPTIONS = (json.JSONDecodeError, orjson.JSONDecodeError)
+JSON_DECODE_EXCEPTIONS = (json.JSONDecodeError, orjson.JSONDecodeError, ValueError)
 
 
 def loads(s: str | bytes | bytearray | memoryview) -> Any:
@@ -41,7 +42,10 @@ def loads(s: str | bytes | bytearray | memoryview) -> Any:
     try:
         return orjson.loads(s)
     except orjson.JSONDecodeError:
-        return commentjson.loads(s)
+        try:
+            return commentjson.loads(s)
+        except LarkError as ex:
+            raise ValueError(f"Failed to parse JSON: {ex}") from ex
 
 
 def dumps(data: Any) -> str:

--- a/tests/test_hkjson.py
+++ b/tests/test_hkjson.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import pytest
+
 import aiohomekit.hkjson as hkjson
 
 
@@ -27,3 +29,9 @@ def test_loads_trailing_comma():
             {"aid": 10, "iid": 13, "value": 20.5},
         ]
     }
+
+
+def test_loads_empty_document():
+    """Test that empty document raises ValueError instead of lark error."""
+    with pytest.raises(ValueError, match="Failed to parse JSON"):
+        hkjson.loads("")


### PR DESCRIPTION
background: https://github.com/home-assistant/core/issues/153070

If a device returns an empty document instread of JSON we did not catch this case