### PR TITLE
Replace bleak_scanner_instance with bleak_scanner_factory

### DIFF
--- a/aiohomekit/controller/ble/controller.py
+++ b/aiohomekit/controller/ble/controller.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from collections.abc import AsyncIterable
+from collections.abc import AsyncIterable, Callable
 
 from bleak import BleakScanner
 from bleak.backends.device import BLEDevice
-from bleak.backends.scanner import AdvertisementData
+from bleak.backends.scanner import AdvertisementData, AdvertisementDataCallback
 from bleak.exc import BleakDBusError, BleakError
 
 from aiohomekit.characteristic_cache import CharacteristicCacheType
@@ -42,10 +42,11 @@ class BleController(AbstractController):
     def __init__(
         self,
         char_cache: CharacteristicCacheType,
-        bleak_scanner_instance: BleakScanner | None = None,
+        bleak_scanner_factory: Callable[[AdvertisementDataCallback], BleakScanner] | None = None,
     ) -> None:
         super().__init__(char_cache=char_cache)
-        self._scanner = bleak_scanner_instance
+        self._scanner: BleakScanner | None = None
+        self._bleak_scanner_factory = bleak_scanner_factory
         self._ble_futures: dict[str, list[asyncio.Future[BLEDevice]]] = {}
 
     def _device_detected(self, device: BLEDevice, advertisement_data: AdvertisementData) -> None:
@@ -112,17 +113,18 @@ class BleController(AbstractController):
         self.discoveries[data.id] = BleDiscovery(self, device, data, advertisement_data)
 
     async def async_start(self) -> None:
-        logger.debug("Starting BLE controller with instance: %s", self._scanner)
-        if not self._scanner:
-            try:
-                self._scanner = BleakScanner()
-            except (FileNotFoundError, BleakDBusError, BleakError) as e:
-                logger.debug("Failed to init scanner, HAP-BLE not available: %s", str(e))
-                self._scanner = None
-                return
-
         try:
-            self._scanner.register_detection_callback(self._device_detected)
+            if self._bleak_scanner_factory is not None:
+                self._scanner = self._bleak_scanner_factory(self._device_detected)
+            else:
+                self._scanner = BleakScanner(detection_callback=self._device_detected)
+        except (FileNotFoundError, BleakDBusError, BleakError) as e:
+            logger.debug("Failed to init scanner, HAP-BLE not available: %s", str(e))
+            self._scanner = None
+            return
+
+        logger.debug("Starting BLE controller with instance: %s", self._scanner)
+        try:
             await self._scanner.start()
         except (FileNotFoundError, BleakDBusError, BleakError) as e:
             logger.debug("Failed to start scanner, HAP-BLE not available: %s", str(e))
@@ -131,7 +133,6 @@ class BleController(AbstractController):
     async def async_stop(self, *args):
         if self._scanner:
             await self._scanner.stop()
-            self._scanner.register_detection_callback(None)
             self._scanner = None
 
     async def async_reachable(self, device_id: str, timeout: float = 10) -> bool:

--- a/aiohomekit/controller/controller.py
+++ b/aiohomekit/controller/controller.py
@@ -18,10 +18,11 @@ from __future__ import annotations
 import asyncio
 import pathlib
 from asyncio.log import logger
-from collections.abc import AsyncIterable
+from collections.abc import AsyncIterable, Callable
 from contextlib import AsyncExitStack
 
 from bleak import BleakScanner
+from bleak.backends.scanner import AdvertisementDataCallback
 from zeroconf.asyncio import AsyncZeroconf
 
 from aiohomekit import hkjson
@@ -56,7 +57,7 @@ class Controller(AbstractController):
         self,
         async_zeroconf_instance: AsyncZeroconf | None = None,
         char_cache: CharacteristicCacheType | None = None,
-        bleak_scanner_instance: BleakScanner | None = None,
+        bleak_scanner_factory: Callable[[AdvertisementDataCallback], BleakScanner] | None = None,
     ) -> None:
         """
         Initialize an empty controller. Use 'load_data()' to load the pairing data.
@@ -66,7 +67,7 @@ class Controller(AbstractController):
         super().__init__(char_cache=char_cache or CharacteristicCacheMemory())
 
         self._async_zeroconf_instance = async_zeroconf_instance
-        self._bleak_scanner_instance = bleak_scanner_instance
+        self._bleak_scanner_factory = bleak_scanner_factory
 
         self.transports: dict[TransportType, AbstractController] = {}
         self._tasks = AsyncExitStack()
@@ -99,7 +100,7 @@ class Controller(AbstractController):
                 )
             )
 
-        if BLE_TRANSPORT_SUPPORTED or self._bleak_scanner_instance:
+        if BLE_TRANSPORT_SUPPORTED or self._bleak_scanner_factory:
             from .ble.controller import (
                 BleController,  # pylint: disable=import-outside-toplevel
             )
@@ -107,7 +108,7 @@ class Controller(AbstractController):
             await self._async_register_backend(
                 BleController(
                     char_cache=self._char_cache,
-                    bleak_scanner_instance=self._bleak_scanner_instance,
+                    bleak_scanner_factory=self._bleak_scanner_factory,
                 )
             )
 

--- a/aiohomekit/testing.py
+++ b/aiohomekit/testing.py
@@ -349,7 +349,7 @@ class FakeController(AbstractController):
 
     transport_type = TransportType.IP
 
-    def __init__(self, async_zeroconf_instance=None, char_cache=None, bleak_scanner_instance=None):
+    def __init__(self, async_zeroconf_instance=None, char_cache=None, bleak_scanner_factory=None):
         super().__init__(char_cache=char_cache or CharacteristicCacheMemory())
 
     def add_device(self, accessories):

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1,4 +1,4 @@
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -28,12 +28,17 @@ async def test_passing_in_bleak_to_controller():
 
     Passing in the instance should enable BLE scanning.
     """
+    scanner = AsyncMock()
+
+    def _factory(detection_callback):
+        return scanner
+
     with (
         patch.object(controller_module, "BLE_TRANSPORT_SUPPORTED", False),
         patch.object(controller_module, "COAP_TRANSPORT_SUPPORTED", False),
         patch.object(controller_module, "IP_TRANSPORT_SUPPORTED", False),
     ):
-        controller = Controller(bleak_scanner_instance=AsyncMock(register_detection_callback=MagicMock()))
+        controller = Controller(bleak_scanner_factory=_factory)
         await controller.async_start()
 
     assert len(controller.transports) == 1


### PR DESCRIPTION
bleak removed register_detection_callback, so the detection callback must now be passed via the BleakScanner constructor. There is no way to add it after construction, so accepting an already built scanner no longer works.

Switch the Controller API to accept a factory; the factory takes the detection callback and returns the scanner. Callers like Home Assistant can now build the wrapper at the right moment, e.g. partial(bluetooth.async_get_scanner, hass).

This is a breaking change to the Controller signature, but it is forced by the upstream bleak removal; there is no compatible alternative.