### PR TITLE
Clear the BLE client when disconnect fails with a dead dbus socket

### DIFF
--- a/aiohomekit/controller/ble/pairing.py
+++ b/aiohomekit/controller/ble/pairing.py
@@ -903,7 +903,10 @@ class BlePairing(AbstractPairing):
             return
         try:
             await self.client.disconnect()
-        except BleakError:
+        except BLEAK_EXCEPTIONS:
+            # A dead D-Bus socket raises EOFError, so catch the broad retry
+            # set; the client must always be cleared or is_connected stays
+            # a stale True and the connection is never reestablished.
             logger.debug(
                 "%s: Failed to close connection, client may have already closed it; rssi=%s",
                 self.name,

--- a/tests/test_controller_ble.py
+++ b/tests/test_controller_ble.py
@@ -10,6 +10,13 @@ import pytest
 
 from aiohomekit.characteristic_cache import CharacteristicCacheMemory
 from aiohomekit.controller.ble.controller import BleController
+from aiohomekit.controller.ble.pairing import BlePairing
+
+BLE_PAIRING_DATA = {
+    "AccessoryPairingID": "aa:bb:cc:dd:ee:ff",
+    "AccessoryAddress": "AA:BB:CC:DD:EE:FF",
+    "Connection": "BLE",
+}
 
 ADVERTISEMENT_DATA_DEFAULTS = {
     "local_name": "",
@@ -133,3 +140,38 @@ async def test_async_start_scanner_start_fails(ble_controller: BleController) ->
         await ble_controller.async_start()
 
     assert ble_controller._scanner is None
+
+
+@pytest.fixture
+def ble_pairing(ble_controller: BleController) -> BlePairing:
+    return BlePairing(ble_controller, dict(BLE_PAIRING_DATA))
+
+
+async def test_close_clears_client_when_dbus_connection_died(ble_pairing: BlePairing) -> None:
+    """An EOFError from a dead dbus socket must not leave a stale client behind.
+
+    If the client is not cleared its is_connected can report a stale True
+    forever, and the connection would never be reestablished.
+    """
+    client = AsyncMock()
+    client.is_connected = True
+    client.disconnect.side_effect = EOFError("dbus connection died")
+    ble_pairing.client = client
+
+    await ble_pairing.close()
+
+    client.disconnect.assert_awaited_once()
+    assert ble_pairing.client is None
+
+
+async def test_close_clears_client_on_bleak_error(ble_pairing: BlePairing) -> None:
+    """A BleakError from disconnect still results in the client being cleared."""
+    client = AsyncMock()
+    client.is_connected = True
+    client.disconnect.side_effect = BleakError("Disconnected mid flight")
+    ble_pairing.client = client
+
+    await ble_pairing.close()
+
+    client.disconnect.assert_awaited_once()
+    assert ble_pairing.client is None


### PR DESCRIPTION
## Summary

When the D-Bus socket dies, disconnect raises EOFError and _close_while_locked only caught BleakError, so self.client was never cleared; is_connected then reported a stale True forever and _ensure_connected never reconnected, which is the permanent BLE stall in #534. The root cause is also being fixed upstream in hbldh/bleak#2012, and Bluetooth-Devices/bleak-retry-connector#309 makes transient socket errors retry; this change makes aiohomekit recover on any released bleak version.

## Changes

_close_while_locked now catches the broad retry exception set, which includes EOFError and BrokenPipeError, so the client is always cleared and connection state reset after a failed disconnect.

## Testing

New tests cover a client whose disconnect raises EOFError and one raising BleakError, asserting the client is cleared in both cases; full suite passes.

fixes #534
