### PR TITLE
Skip BLE characteristics that return a success PDU without a value

### DIFF
--- a/aiohomekit/controller/ble/pairing.py
+++ b/aiohomekit/controller/ble/pairing.py
@@ -75,6 +75,7 @@ from .client import (
     raise_for_pdu_status,
 )
 from .connection import establish_connection
+from .const import AdditionalParameterTypes
 from .key import BroadcastDecryptionKey, DecryptionKey, EncryptionKey
 from .manufacturer_data import HomeKitAdvertisement, HomeKitEncryptedNotification
 from .structs import (
@@ -1360,7 +1361,20 @@ class BlePairing(AbstractPairing):
                     )
                     continue
 
-                decoded = dict(TLV.decode_bytes(data))[1]
+                decoded = dict(TLV.decode_bytes(data)).get(AdditionalParameterTypes.Value.value)
+                if decoded is None:
+                    # Some accessories, such as the UltraLoq Bolt, return a
+                    # success PDU without a value for some characteristics;
+                    # skip them so the rest of the accessory still works.
+                    logger.debug(
+                        "%s: Reading characteristic %s (%s) with iid %s returned no value, data=%s (skipped)",
+                        self.name,
+                        char.description,
+                        char.type,
+                        char.iid,
+                        data,
+                    )
+                    continue
 
                 logger.debug(
                     "%s: Read characteristic %s (%s) with iid %s got data, expected format is %s: data=%s decoded=%s",

--- a/tests/test_controller_ble.py
+++ b/tests/test_controller_ble.py
@@ -9,8 +9,14 @@ from bleak.exc import BleakError
 import pytest
 
 from aiohomekit.characteristic_cache import CharacteristicCacheMemory
+from aiohomekit.controller.ble.const import AdditionalParameterTypes
 from aiohomekit.controller.ble.controller import BleController
 from aiohomekit.controller.ble.pairing import BlePairing
+from aiohomekit.model import Accessory
+from aiohomekit.model.characteristics import Characteristic, CharacteristicsTypes
+from aiohomekit.model.services import ServicesTypes
+from aiohomekit.pdu import OpCode
+from aiohomekit.protocol.tlv import TLV
 
 BLE_PAIRING_DATA = {
     "AccessoryPairingID": "aa:bb:cc:dd:ee:ff",
@@ -175,3 +181,33 @@ async def test_close_clears_client_on_bleak_error(ble_pairing: BlePairing) -> No
 
     client.disconnect.assert_awaited_once()
     assert ble_pairing.client is None
+
+
+async def test_get_characteristics_skips_missing_value_response(
+    ble_pairing: BlePairing,
+) -> None:
+    """A success PDU without a value TLV must not fail the whole read.
+
+    Some accessories, such as the UltraLoq Bolt, return a success PDU
+    without a value for some characteristics; they are skipped so the
+    rest of the accessory still works.
+    """
+    accessory = Accessory.create_with_info(
+        "00:00:00:00:00:01", "Bolt", "UltraLoq", "Bolt Fingerprint", "0001", "0.1"
+    )
+    service = accessory.add_service(ServicesTypes.LIGHTBULB)
+    good_char = service.add_char(CharacteristicsTypes.ON)
+    bad_char = service.add_char(CharacteristicsTypes.BRIGHTNESS)
+
+    async def fake_request_under_lock(
+        opcode: OpCode, char: Characteristic, data: bytes | None = None
+    ) -> bytes:
+        if char is good_char:
+            return TLV.encode_list([(AdditionalParameterTypes.Value.value, b"\x01")])
+        return b""
+
+    with patch.object(ble_pairing, "_async_request_under_lock", fake_request_under_lock):
+        async with ble_pairing._operation_lock:
+            results = await ble_pairing._get_characteristics_while_connected([good_char, bad_char])
+
+    assert results == {(1, good_char.iid): {"value": True}}


### PR DESCRIPTION
## Summary

Some accessories, such as the UltraLoq Bolt Fingerprint, return a success CHAR_READ PDU whose TLV has no value parameter; the hard subscript in _get_characteristics_while_connected raised KeyError: 1 and failed the whole config entry setup in Home Assistant, see home-assistant/core#168578. Apple Home tolerates the same device.

## Changes

The read loop now looks the value up with get and skips the characteristic with a debug log when it is missing, matching the existing PDUStatusError and struct.error skip paths on either side of it; _populate_char_values already tolerates a characteristic without a value. The pairing management paths that hard index the same TLV key are intentionally untouched, they should fail loudly.

## Testing

New test drives the read loop with one valid response and one success response without a value TLV, asserting the good characteristic decodes and the bad one is skipped; the test reproduces the KeyError on the previous code, full suite passes.
