### PR TITLE
Skip linked service references to iids that do not exist

### DIFF
--- a/aiohomekit/model/__init__.py
+++ b/aiohomekit/model/__init__.py
@@ -304,13 +304,18 @@ class Accessory:
                     char.set_value(char_data["value"])
 
         for service_data in data["services"]:
-            for linked_service in service_data.get("linked", []):
+            if not (linked_iids := service_data.get("linked")):
+                continue
+            service = accessory.services.iid(service_data["iid"])
+            for linked_service in linked_iids:
                 # https://github.com/home-assistant/core/issues/100160
                 # The Schlage Encode Plus can contain a 0 in this list which we have to ignore
-                if linked_service:
-                    accessory.services.iid(service_data["iid"]).add_linked_service(
-                        accessory.services.iid(linked_service)
-                    )
+                #
+                # https://github.com/home-assistant/core/issues/175416
+                # The Yeelight Pro Gateway references linked service iids that
+                # do not exist; skip them so the accessory still parses
+                if linked_service and (linked := accessory.services.iid_or_none(linked_service)):
+                    service.add_linked_service(linked)
 
         return accessory
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -94,6 +94,40 @@ def test_linked_services():
     assert service.linked[0].type == "000000CC-0000-1000-8000-0026BB765291"
 
 
+def test_linked_service_missing_iid_is_skipped() -> None:
+    """Linked service iids that do not exist are dropped instead of raising.
+
+    The Yeelight Pro Gateway references linked service iids that are not
+    present in the accessory, and the Schlage Encode Plus lists iid 0;
+    both must not prevent the accessory from parsing.
+    """
+    accessories = Accessories.from_list(
+        [
+            {
+                "aid": 28,
+                "services": [
+                    {
+                        "iid": 80,
+                        "type": ServicesTypes.SERVICE_LABEL,
+                        "characteristics": [],
+                        "linked": [0, 82, 88],
+                    },
+                    {
+                        "iid": 82,
+                        "type": ServicesTypes.STATELESS_PROGRAMMABLE_SWITCH,
+                        "characteristics": [],
+                    },
+                ],
+            }
+        ]
+    )
+
+    service = accessories.aid(28).services.iid(80)
+    assert [linked.iid for linked in service.linked] == [82]
+    serialized = accessories.serialize()
+    assert serialized[0]["services"][0]["linked"] == [82]
+
+
 def test_get_by_name():
     name = "Hue dimmer switch button 3"
     a = Accessories.from_file("tests/fixtures/hue_bridge.json").aid(6623462389072572)


### PR DESCRIPTION
## Summary

The Yeelight Pro Gateway exposes ControlPanel accessories whose service label links reference service iids that do not exist in the accessory, which raised KeyError while parsing the accessories payload and prevented the whole bridge from pairing in Home Assistant, see home-assistant/core#175416. The gateway then reports itself as paired so users have to reset it to retry.

## Changes

The linked service loop in Accessory.create_from_dict now resolves each linked iid with iid_or_none and skips references that do not exist, extending the existing Schlage Encode Plus guard for iid 0 on the same lines; serialization only emits resolved services so the dropped references stay gone. The parent service lookup is hoisted out of the inner loop while touching it.

## Testing

New test parses an accessory with a linked list containing iid 0, a dangling iid, and a real one, asserting only the real service is linked and that serialization round trips without the dangling reference; the test reproduces the KeyError on the previous code, full suite passes.
